### PR TITLE
Draft: Log an error instead of info if task creation failed in TaskExecutor

### DIFF
--- a/src/ewoksorange/bindings/taskexecutor.py
+++ b/src/ewoksorange/bindings/taskexecutor.py
@@ -26,7 +26,7 @@ class TaskExecutor:
             self.__task = self.__ewokstaskclass(**kwargs)
         except TaskInputError as e:
             self.__task_init_exception = e
-            _logger.info(f"task initialization failed: {e}")
+            _logger.error(f"task initialization failed: {e}")
 
     def execute_task(self) -> None:
         if not self.has_task:


### PR DESCRIPTION
***In GitLab by @loichuder on Feb 8, 2024, 13:42 GMT+1:***

By default, `INFO` logs are not shown by `ewoks-canvas` so this error can pass undetected.

**Reviewers:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/157*