### PR TITLE
Update setup.cfg: fix, PyQt6 is not available for python 3.8 or lower

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,8 @@ oasys.widgets =
 
 [options.extras_require]
 full =
-    PyQt6
+    PyQt6; python_version >= '3.9'
+    PyQt5; python_version < '3.9'
 test =
     %(full)s
     pytest >=7


### PR DESCRIPTION
***In GitLab by @payno on Jan 14, 2025, 13:27 GMT+1:***



**Assignees:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/210*