### PR TITLE
missing .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    setup.py


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 7, 2021, 23:22 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/7*