### PR TITLE
Missing "openclass" WidgetMetaClass parameter in old Orange3 versions

### DIFF
--- a/ewoksorange/bindings.py
+++ b/ewoksorange/bindings.py
@@ -13,6 +13,7 @@ from ewokscore.variable import Variable
 from ewokscore.task import TaskInputError
 from ewokscore.hashing import UniversalHashable
 from ewokscore.hashing import MissingData
+import inspect
 from . import owsconvert
 
 MISSING_DATA = UniversalHashable.MISSING_DATA
@@ -86,7 +87,15 @@ class OWEwoksWidgetMetaClass(WidgetMetaClass):
         return super().__new__(metacls, name, bases, attr, **kw)
 
 
-class OWEwoksWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, openclass=True):
+# insure compatibility between old orange widget and new
+# orangewidget.widget.WidgetMetaClass. This was before split of the two
+# projects. Parameter name "openclass" is undefined on the old version
+ow_build_opts = {}
+if "openclass" in inspect.getargspec(WidgetMetaClass)[0]:
+    ow_build_opts["openclass"] = True
+
+
+class OWEwoksWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_opts):
     MISSING_DATA = MISSING_DATA
 
     def __init__(self, *args, **kw):


### PR DESCRIPTION
***In GitLab by @payno on Jul 7, 2021, 17:06 GMT+2:***

Introduced here: https://redirect.github.com/biolab/orange-widget-base/commit/86f4a5d71061fe29f28c4df92acc5e5c661404bc

First released in orange-widget-base 4.0.1 so that's Orange 3.23.0 (tomwer seems to be on 3.20.1)

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/5*