### PR TITLE
Update .gitlab-ci.yml. Remove "apt-get update"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,6 @@ lint:
 test:
   stage: test
   before_script:
-    - apt-get update
     - pip install pytest-cov
   script:
     - pip install .[test]


### PR DESCRIPTION
***In GitLab by @payno on Jul 20, 2021, 13:31 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/11*