### PR TITLE
Resolve "threaded widgets do not work with last orange3 version"

### DIFF
--- a/ewoksorange/bindings/taskexecutor_queue.py
+++ b/ewoksorange/bindings/taskexecutor_queue.py
@@ -52,6 +52,7 @@ class TaskExecutorQueue(QObject, Queue):
             self._process_next()
 
     def stop(self):
+        self._taskExecutor.finished.disconnect(self._process_ended)
         while not self.empty():
             self.get()
         self._taskExecutor.blockSignals(True)


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 19, 2021, 10:02 GMT+2:***

Closes #9

https://orange-widget-base.readthedocs.io/en/latest/tutorial-responsive-gui.html

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/31*