### PR TITLE
Resolve "Allow ewoks widgets to be connected to orange widgets"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ test-3.6-orange3-fork:
   before_script:
     - export QT_QPA_PLATFORM=offscreen
     # missing dependencies in the Orange3 fork
-    - pip install numpy scipy PyQt5 silx chardet
+    - pip install numpy scipy PyQt5 silx chardet sklearn
     # hard fork of Orange3
     - pip install git+https://github.com/payno/orange3.git
 

--- a/ewoksorange/__init__.py
+++ b/ewoksorange/__init__.py
@@ -1,3 +1,7 @@
+from .bindings.owsignal_manager import patch_signal_manager
+
+patch_signal_manager()
+
 from .bindings import execute_graph  # noqa F401
 
 __version__ = "0.0.3-alpha"

--- a/ewoksorange/bindings/__init__.py
+++ b/ewoksorange/bindings/__init__.py
@@ -1,5 +1,5 @@
 from .progress import *  # noqa
 from .bindings import *  # noqa
-from .ewoksow import *  # noqa
+from .owwidgets import *  # noqa
 from .owsconvert import *  # noqa
 from .taskwrapper import *  # noqa

--- a/ewoksorange/bindings/owsettings.py
+++ b/ewoksorange/bindings/owsettings.py
@@ -1,0 +1,10 @@
+import inspect
+from Orange.widgets.settings import Setting
+
+
+def is_setting(obj):
+    return isinstance(obj, Setting)
+
+
+def get_settings(widget_class):
+    return dict(inspect.getmembers(widget_class, is_setting))

--- a/ewoksorange/bindings/owsignal_manager.py
+++ b/ewoksorange/bindings/owsignal_manager.py
@@ -1,0 +1,209 @@
+try:
+    OBSOLETE_ORANGE = True
+    from Orange.canvas.scheme.widgetsscheme import (
+        WidgetsSignalManager as _SignalManagerWithSchemeOrg,
+    )
+    import Orange.canvas.scheme.widgetsscheme as widgetsscheme_module
+
+    class _SignalManagerWithScheme(_SignalManagerWithSchemeOrg):
+        def has_pending(self):
+            return bool(self._input_queue)
+
+
+except ImportError:
+    OBSOLETE_ORANGE = False
+    from orangewidget.workflow.widgetsscheme import (
+        WidgetsSignalManager as _SignalManagerWithScheme,
+    )
+    import orangewidget.workflow.widgetsscheme as widgetsscheme_module
+
+    from orangewidget.utils.signals import notify_input_helper
+
+from ewokscore.variable import value_from_transfer
+
+from .owwidgets import is_native_widget
+from .qtapp import QtEvent
+from ..bindings.owsignals import get_input_names, get_output_names
+
+
+class _MissingSignalValue:
+    """Indicates a missing signal value and allows waiting for the real signal value"""
+
+    completed = QtEvent()
+
+
+class _SignalValues:
+    """Store signal values per widget and allow waiting for a value"""
+
+    def __init__(self):
+        self.values = dict()
+
+    def _get_value(self, widget, signal_name):
+        if not isinstance(signal_name, str):
+            signal_name = signal_name.name
+        values = self.values.setdefault(widget, dict())
+        if signal_name not in values:
+            values[signal_name] = _MissingSignalValue()
+        return values[signal_name]
+
+    def _set_value(self, widget, signal_name, value):
+        if not isinstance(signal_name, str):
+            signal_name = signal_name.name
+        values = self.values.setdefault(widget, dict())
+        values[signal_name] = value
+
+    def set_value(self, widget, signal_name, value):
+        previous_value = self._get_value(widget, signal_name)
+        self._set_value(widget, signal_name, value)
+        if isinstance(previous_value, _MissingSignalValue):
+            previous_value.completed.set()
+
+    def invalidate_value(self, widget, signal_name):
+        previous_value = self._get_value(widget, signal_name)
+        if isinstance(previous_value, _MissingSignalValue):
+            return
+        self.set_value(widget, signal_name, _MissingSignalValue())
+
+    def get_value(self, widget, signal_name, timeout=None):
+        value = self._get_value(widget, signal_name)
+        if isinstance(value, _MissingSignalValue):
+            value.completed.wait(timeout=timeout)
+            value = self._get_value(widget, signal_name)
+        return value
+
+    def has_value(self, widget, signal_name):
+        value = self._get_value(widget, signal_name)
+        return not isinstance(value, _MissingSignalValue)
+
+
+class SignalManagerWithOutputTracking:
+    """Store input and output signal value per widget. Knows
+    when a widget is "executed" or not.
+
+    Losely based on Orange.widgets.tests.base.DummySignalManager
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.output_values = _SignalValues()
+        self.input_values = _SignalValues()
+        self._widget_cache = dict()
+        super().__init__(*args, **kwargs)
+
+    def set_output_value(self, widget, signal_name, value):
+        self.output_values.set_value(widget, signal_name, value)
+
+    def invalidate_output_value(self, widget, signal_name):
+        self.output_values.invalidate_value(widget, signal_name)
+
+    def get_output_value(self, widget, signal_name, timeout=None):
+        return self.output_values.get_value(widget, signal_name, timeout=timeout)
+
+    def has_output_value(self, widget, signal_name):
+        return self.output_values.has_value(widget, signal_name)
+
+    def set_input_value(self, widget, signal_name, value):
+        self.input_values.set_value(widget, signal_name, value)
+
+    def invalidate_input_value(self, widget, signal_name):
+        self.input_values.invalidate_value(widget, signal_name)
+
+    def get_input_value(self, widget, signal_name, timeout=None):
+        return self.input_values.get_value(widget, signal_name, timeout=timeout)
+
+    def has_input_value(self, widget, signal_name):
+        return self.input_values.has_value(widget, signal_name)
+
+    def widget_is_executed(self, widget):
+        variable_names, widget_has_outputs = self._widget_cache.get(
+            widget, (None, None)
+        )
+        if variable_names is None:
+            variable_names = get_output_names(widget)
+            widget_has_outputs = variable_names
+            if not widget_has_outputs:
+                variable_names = get_input_names(widget)
+            self._widget_cache[widget] = variable_names, widget_has_outputs
+        if widget_has_outputs:
+            # Widget is executed when all outputs are set
+            for name in variable_names:
+                if not self.has_output_value(widget, name):
+                    return False
+        else:
+            # Widget has no outputs
+            if variable_names:
+                # Widget is executed when all inputs are set
+                for name in variable_names:
+                    if not self.has_input_value(widget, name):
+                        return False
+            else:
+                # Widget is executed when any input is set
+                return bool(self.input_values.values.get(widget, False))
+        return True
+
+
+class SignalManagerWithoutScheme(SignalManagerWithOutputTracking):
+    """Used when no Orange canvas is present.
+
+    Only needs to keep track of widget outputs because data between tasks
+    is passed by the Ewoks mechanism, not the Orange mechanism (signal manager).
+    """
+
+    def send(self, widget, signal_name, value, *args, **kwargs):
+        self.set_output_value(widget, signal_name, value)
+
+
+class SignalManagerWithScheme(
+    SignalManagerWithOutputTracking, _SignalManagerWithScheme
+):
+    """Used when the Orange canvas is present.
+
+    Dereference `Variable` types for native Orange widget inputs.
+    """
+
+    def send(self, widget, signal_name, value, *args, **kwargs):
+        super().send(widget, signal_name, value, *args, **kwargs)
+        self.set_output_value(widget, signal_name, value)
+
+    def process_signals_for_widget(self, node, widget, signals):
+        for signal in signals:
+            if OBSOLETE_ORANGE:
+                signal_name = signal.link.sink_channel
+            else:
+                signal_name = signal.channel.name
+            self.set_input_value(widget, signal_name, signal.value)
+        if is_native_widget(widget):
+            modified_signals = list()
+            for signal in signals:
+                sinfo = signal._asdict()
+                sinfo["value"] = value_from_transfer(sinfo["value"])
+                modified_signals.append(type(signal)(**sinfo))
+            signals = modified_signals
+        super().process_signals_for_widget(node, widget, signals)
+
+    def invalidate(self, node, channel):
+        super().invalidate(node, channel)
+        widget = self.scheme().widget_for_node(node)
+        if widget is None:
+            return
+        self.invalidate_input_value(widget, channel.name, _MissingSignalValue())
+
+    def widget_is_executed(self, widget):
+        if self.has_pending():
+            return False  # The widget might be executed again
+        return super().widget_is_executed(widget)
+
+
+def set_input_value(widget, signal, value, index):
+    key = id(widget), signal.name, signal.id
+    if OBSOLETE_ORANGE:
+        handler = getattr(widget, signal.handler)
+        if signal.single:
+            handler(value)
+        else:
+            handler(value, key)
+    else:
+        notify_input_helper(signal, widget, value, key=key, index=index)
+
+
+def patch_signal_manager():
+    widgetsscheme_module.WidgetsSignalManager = SignalManagerWithScheme

--- a/ewoksorange/bindings/owsignals.py
+++ b/ewoksorange/bindings/owsignals.py
@@ -1,7 +1,6 @@
 import inspect
 from Orange.widgets.widget import Input, Output
 
-
 SIGNAL_TYPES = (Input, Output)
 
 
@@ -10,6 +9,7 @@ def is_signal(obj):
 
 
 def get_signals(signals_class) -> dict:
+    """Returns a map from ewoks names to signal objects"""
     # TODO: getsignals doesn't work in the Orange3 hard-fork
     # from orangewidget.utils.signals import getsignals
     # return dict(getsignals(signals_class))
@@ -81,3 +81,13 @@ def validate_outputs(namespace):
         namespace["Outputs"] = Outputs
 
     _validate_signals(namespace, "outputs", namespace["ewokstaskclass"].output_names())
+
+
+def get_input_names(widget_class):
+    """Returns the Orange signal names, not the Ewoks output names"""
+    return [signal.name for signal in get_signals(widget_class.Outputs).values()]
+
+
+def get_output_names(widget_class):
+    """Returns the Orange signal names, not the Ewoks output names"""
+    return [signal.name for signal in get_signals(widget_class.Outputs).values()]

--- a/ewoksorange/bindings/qtapp.py
+++ b/ewoksorange/bindings/qtapp.py
@@ -63,12 +63,14 @@ def process_qtapp_events():
 
 
 class QtEvent:
-    """Event that also works for Qt applications without event loop"""
+    """Event that also works for Qt applications with an event loop
+    that need to run manually"""
 
     def __init__(self):
         self.__flag = False
 
     def wait(self, timeout=None):
+        """Processes events associated to the calling thread while waiting"""
         global APP
         if timeout is not None:
             t0 = time.time()

--- a/ewoksorange/bindings/taskwrapper.py
+++ b/ewoksorange/bindings/taskwrapper.py
@@ -1,27 +1,46 @@
-from Orange.widgets.widget import OWWidget
+from typing import List, Tuple
+
 from ewokscore import Task
 from ewokscore.utils import qualname
 from ewokscore.utils import import_qualname
-from .qtapp import ensure_qtapp
-from ewoksorange.bindings.qtapp import QtEvent
+from ewokscore.variable import value_from_transfer
 
+from .qtapp import ensure_qtapp
+from .qtapp import process_qtapp_events
+from .qtapp import QtEvent
+from .owwidgets import is_ewoks_widget_class
+from .owwidgets import is_native_widget_class
+from . import owsignals
+from . import owsettings
+from .owsignal_manager import SignalManagerWithoutScheme
+from .owsignal_manager import set_input_value
 
 __all__ = ["OWWIDGET_TASKS_GENERATOR"]
 
 
 def owwidget_task_wrapper(widget_qualname: str) -> Task:
+    """Create a task that does the computation through an orange widget.
+    When the widget is an ewoks widget, still use the widget and not
+    the corresponding task class directly.
+    """
     widget_class = import_qualname(widget_qualname)
-    try:
-        is_widget = issubclass(widget_class, OWWidget)
-    except TypeError:
-        is_widget = False
-    if not is_widget:
-        raise TypeError(widget_class, "expected to be an OWWidget")
-
     registry_name = widget_qualname + ".wrapper"
     if registry_name in Task.get_subclass_names():
         return Task.get_subclass(registry_name)
 
+    if is_ewoks_widget_class(widget_class):
+        return _ewoks_owwidget_task_wrapper(registry_name, widget_class)
+    elif is_native_widget_class(widget_class):
+        return _native_owwidget_task_wrapper(registry_name, widget_class)
+    else:
+        raise TypeError(widget_class, "expected to be an OWWidget")
+
+
+OWWIDGET_TASKS_GENERATOR = qualname(owwidget_task_wrapper)
+
+
+def _ewoks_owwidget_task_wrapper(registry_name, widget_class) -> Task:
+    """Wrap an Ewoks widget with an Ewoks task"""
     all_input_names = widget_class.input_names()
     try:
         ewokstaskclass = widget_class.ewokstaskclass
@@ -31,13 +50,14 @@ def owwidget_task_wrapper(widget_qualname: str) -> Task:
         assert all_input_names == expected
     except AttributeError:
         input_names = all_input_names
-        optional_input_names = None
+        optional_input_names = tuple()
+    output_names = widget_class.output_names()
 
     class WrapperTask(
         Task,
         input_names=input_names,
         optional_input_names=optional_input_names,
-        output_names=widget_class.output_names(),
+        output_names=output_names,
         registry_name=registry_name,
     ):
         def __init__(self, **kwargs):
@@ -51,18 +71,21 @@ def owwidget_task_wrapper(widget_qualname: str) -> Task:
             self.widget = widget_class()
             try:
                 self.widget.task_output_changed_callbacks.add(self.receiveOutputSend)
-                # Trigger the input handlers
-                values = self.input_values
-                for signal in self.widget.get_signals("inputs"):
-                    handler = getattr(self.widget, signal.handler)
-                    handler(values[signal.ewoksname])
 
-                # Send the outputs
+                # Call the input setters
+                values = self.input_values
+                for index, signal in enumerate(self.widget.get_signals("inputs")):
+                    set_input_value(
+                        self.widget, signal, values[signal.ewoksname], index
+                    )
+
+                # Start calculation
                 self.widget.handleNewSignals()
 
+                # Wait for the result
                 self.outputsReceived.wait()
             finally:
-                self.widget.destroy()
+                self.widget.close()
                 self.widget = None
                 self.outputsReceived = None
 
@@ -77,4 +100,103 @@ def owwidget_task_wrapper(widget_qualname: str) -> Task:
     return WrapperTask
 
 
-OWWIDGET_TASKS_GENERATOR = qualname(owwidget_task_wrapper)
+def _native_owwidget_task_wrapper(registry_name, widget_class) -> Task:
+    """Wrap a native Orange widget with an Ewoks task"""
+    input_signals = owsignals.get_signals(widget_class.Inputs)
+    optional_input_names = set(input_signals.keys())
+    output_signals = owsignals.get_signals(widget_class.Outputs)
+    output_names = set(output_signals.keys())
+    orange_to_ewoks_namemap = {
+        ewoks_name: signal.name for ewoks_name, signal in output_signals.items()
+    }
+    input_names = tuple()
+    setting_names = list(owsettings.get_settings(widget_class))
+
+    class WrapperTask(
+        Task,
+        input_names=input_names,
+        optional_input_names=optional_input_names,
+        output_names=output_names,
+        registry_name=registry_name,
+    ):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.outputsReceived = None
+
+        def run(self):
+            input_list, settings_dict = self._parse_input_values()
+
+            # Create widget with the proper settings
+            ensure_qtapp()
+            widget = instantiate_owwidget(
+                widget_class,
+                signal_manager=SignalManagerWithoutScheme(),
+                stored_settings=settings_dict,
+            )
+            try:
+                # Call input setters
+                for index, (signal, value) in enumerate(input_list):
+                    set_input_value(widget, signal, value, index)
+
+                # Start calculation
+                widget.handleNewSignals()
+
+                # Wait for the result
+                process_qtapp_events()
+
+                for ewoks_name, orange_name in orange_to_ewoks_namemap.items():
+                    value = widget.signalManager.get_output_value(
+                        widget, orange_name, timeout=None
+                    )
+                    self.output_variables[ewoks_name].value = value
+            finally:
+                widget.close()
+
+        def _parse_input_values(self) -> Tuple[List, dict]:
+            values = self.input_values
+
+            used_values = set()
+            settings_dict = dict()
+            input_list = list()
+
+            # Values corresponding to settings
+            for ewoksname in setting_names:
+                if ewoksname not in values:
+                    continue
+                used_values.add(ewoksname)
+                value = value_from_transfer(values[ewoksname])
+                if value is not self.MISSING_DATA:
+                    settings_dict[ewoksname] = value
+
+            # Values corresponding to inputs
+            for signal in widget_class.get_signals("inputs"):
+                ewoksname = owsignals.signal_orange_to_ewoks_name(
+                    widget_class.Inputs, signal.name
+                )
+                if ewoksname not in values:
+                    continue
+                used_values.add(ewoksname)
+                value = value_from_transfer(values[ewoksname])
+                if value is self.MISSING_DATA:
+                    value = None
+                input_list.append((signal, value))
+
+            # Node properties not corresponding to settings or inputs
+            # are used in settings migration
+            unused_values = set(values.keys()) - used_values
+            for ewoksname in unused_values:
+                value = value_from_transfer(values[ewoksname])
+                if value is not self.MISSING_DATA:
+                    settings_dict[ewoksname] = value
+
+            return input_list, settings_dict
+
+    return WrapperTask
+
+
+def instantiate_owwidget(widget_class, signal_manager=None, stored_settings=None):
+    widget = widget_class.__new__(
+        widget_class, signal_manager=signal_manager, stored_settings=stored_settings
+    )
+    widget.__init__()
+    return widget

--- a/ewoksorange/canvas/utils.py
+++ b/ewoksorange/canvas/utils.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+try:
+    OBSOLETE_ORANGE = False
+    from Orange.canvas.mainwindow import MainWindow
+except ImportError:
+    OBSOLETE_ORANGE = True
+    from Orange.canvas.application.canvasmain import CanvasMainWindow as MainWindow
+from ..bindings.qtapp import get_qtapp
+
+
+def get_orange_canvas() -> Optional[MainWindow]:
+    app = get_qtapp()
+    if app is None:
+        return None
+    for widget in app.topLevelWidgets():
+        if isinstance(widget, MainWindow):
+            return widget
+    return None

--- a/ewoksorange/tests/examples/ewoks_example_1_addon/orangecontrib/ewoks_example_category/tutorials/mixed_tutorial1.ows
+++ b/ewoksorange/tests/examples/ewoks_example_1_addon/orangecontrib/ewoks_example_category/tutorials/mixed_tutorial1.ows
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<scheme version="2.0" title="Mixed Ewoks/Native example" description="simple mixed graph">
+	<nodes>
+		<node id="0" name="Adder1" qualified_name="orangecontrib.ewoks_example_category.adder1.Adder1" project_name="ewoks-example-1-addon" version="" title="Adder1" position="(190.0, 271.0)" />
+		<node id="1" name="Adder2" qualified_name="orangecontrib.ewoks_example_category.adder2.Adder2" project_name="ewoks-example-1-addon" version="" title="Adder2" position="(577.0, 267.0)" />
+		<node id="2" name="Python Script" qualified_name="Orange.widgets.data.owpythonscript.OWPythonScript" project_name="Orange3" version="" title="Python Script" position="(390.0, 268.0)" />
+	</nodes>
+	<links>
+		<link id="0" source_node_id="0" sink_node_id="2" source_channel="A + B" sink_channel="Object" enabled="true" />
+		<link id="1" source_node_id="2" sink_node_id="1" source_channel="Object" sink_channel="A" enabled="true" />
+	</links>
+	<annotations />
+	<thumbnail />
+	<node_properties>
+		<properties node_id="0" format="literal">{'default_inputs': {'b': 0, 'a': 1}}</properties>
+		<properties node_id="1" format="literal">{'default_inputs': {'b': 1, 'a': 0}}</properties>
+		<properties node_id="2" format="literal">{'currentScriptIndex': 0, 'scriptLibrary': [], 'scriptText': 'print("Script input:",in_object)\nout_object = in_object + 1\nprint("Script output:", out_object)\n', '__version__': 2}</properties>
+	</node_properties>
+	<session_state>
+		<window_groups />
+	</session_state>
+</scheme>


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 18, 2021, 13:12 GMT+2:***

Closes #7

This MR is about using native Orange widgets in Ewoks.

There are three ways to execute an Orange workflow:

1. Convert it to an ewoks workflow and run it like any other ewoks workflow (no GUI)
   * Ewoks widgets: the corresponding tasks will be used (no Qt dependency)
   * Native Orange widgets: a task class will be created on-the-fly to wrap and "execute" the widget (Qt dependency)
   
   The `run` method of the task wrapper does the following:
   * instantiate the widget with a local signal manager `SignalManagerWithoutScheme`
   * set the *inputs* and *settings* of the widget (dereference `Variable` inputs as native widgets cannot handle them)
   * call `handleNewSignals` on the widget which results in calls to `OWWidget.send` which send output data to the signal manager
   * wait for and retrieve the output from the local signal manager `SignalManagerWithoutScheme`

2. Keep the widgets and use qt signaling like the Orange canvas would do (no GUI, meant for the test suite)
   * `OrangeCanvasHandler` is used to emulate what the Orange canvas is doing but then without the GUI. 
   * `SignalManagerWithScheme` is used to capture the output of the widget and dereference `Variable` inputs for native widgets.

3. Use the Orange canvas (with GUI)
   * `SignalManagerWithScheme` is used to capture the output of the widget and dereference `Variable` inputs for native widgets.


For use cases 2 and 3 we need to replace the signal manager class in Orange (done when importing `ewoksorange`):
```python
from ewoksorange.bindings.owsignal_manager import patch_signal_manager
patch_signal_manager()
```

To enforce signal manager patching in use case 3, the Orange canvas needs to be launched like this
```
python -m ewoksorange.canvas
```

**Assignees:** @woutdenolf

**Reviewers:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/28*