### PR TITLE
'python -m sphinx' was missing project name and release which only 'python...

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,8 @@
 """rm -rf doc/_generated/; python setup.py build_sphinx -E -a
 """
 
+project = "ewoksorange"
+release = "0.1"
 copyright = "2021, ESRF"
 author = "ESRF"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ exclude =
 [build_sphinx]
 project = ewoksorange
 version = attr: ewoksorange.__version__
-release = 0.1
 source-dir = ./doc
 
 [coverage:run]


### PR DESCRIPTION
***In GitLab by @woutdenolf on Apr 8, 2022, 14:27 GMT+2:***

'python -m sphinx' was missing project name and release which only 'python setup.py build_sphinx' had.

**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/74*