### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.2.0 (unreleased)
 
+## 0.1.2
+
+Bug fixes:
+  - ParameterForm: fix serialization for sequences
+
+New features:
+  - OWEwoksBaseWidget: get default inputs with or without missing values
+
 ## 0.1.1
 
 New features:

--- a/src/ewoksorange/__init__.py
+++ b/src/ewoksorange/__init__.py
@@ -8,4 +8,4 @@ from .bindings.owsignal_manager import patch_signal_manager
 patch_signal_manager()
 
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jan 27, 2023, 18:11 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/119*