### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.0 (unreleased)
 
+## 0.1.4
+
+Changes:
+  - use new "engine" argument instead of the deprecated "binding"
+
 ## 0.1.3
 
 New features:

--- a/src/ewoksorange/__init__.py
+++ b/src/ewoksorange/__init__.py
@@ -8,4 +8,4 @@ from .bindings.owsignal_manager import patch_signal_manager
 patch_signal_manager()
 
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 9, 2023, 07:11 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/127*