### PR TITLE
Remove pyqt5 from basic requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,10 @@ orange.canvas.help =
 * = *.ows, *.png, *.svg
 
 [options.extras_require]
+full =
+    PyQt5
 test =
+    %(full)s
     pytest >=7
     importlib_resources
 dev =


### PR DESCRIPTION
***In GitLab by @payno on Aug 23, 2023, 08:44 GMT+2:***

This prevent from using another binding and bring conflict with conda pyqt for a conda installation.

**Assignees:** @payno

**Reviewers:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/141*