### PR TITLE
homogenize API for default inputs, dynamic inputs, task inputs, task outputs

### DIFF
--- a/src/ewoksorange/bindings/owsignals.py
+++ b/src/ewoksorange/bindings/owsignals.py
@@ -114,7 +114,7 @@ def receive_dynamic_input(name: str) -> Callable:
     def setter(self, value):
         # Called by the SignalManager as a result of calling
         # `send` on an upstream output.
-        self._receive_dynamic_input(name, value)
+        self.set_dynamic_input(name, value)
 
     setter.__name__ = setter_name
     return setter


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 2, 2023, 13:41 GMT+2:***

This change was prompted by https://gitlab.esrf.fr/XRD/darfix/-/issues/92 and a user who tried to do something similar

* set a single value
  * set_default_input
  * set_dynamic_input
* get a single value
  * get_default_input_value
  * get_dynamic_input_value
  * get_task_output_value
  * get_task_input_value
* get variable names
  * get_default_input_names
  * get_dynamic_input_names
  * get_input_names
  * get_output_names
* set multiple values
  * update_default_inputs
  * update_dynamic_inputs
* get multiple values
  * get_default_input_values
  * get_dynamic_input_values
  * get_task_output_values
  * get_task_input_values

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/146*