### PR TITLE
Allow hidding some ewoks input and / or output to Orange

### DIFF
--- a/src/ewoksorange/bindings/owsignals.py
+++ b/src/ewoksorange/bindings/owsignals.py
@@ -156,6 +156,9 @@ def _validate_signals_oasys(namespace: dict, direction: str, names: List[str]) -
 
 
 def _validate_signals(namespace: dict, direction: str, names: List[str]) -> None:
+    """
+    convert ewoks inputs or outputs to orange Input and or Output
+    """
     signals_class_name = direction.title()
     is_inputs = direction == "inputs"
     signal_container = namespace[signals_class_name]
@@ -176,7 +179,7 @@ def _validate_signals(namespace: dict, direction: str, names: List[str]) -> None
             namespace[setter.__name__] = signal(setter)
 
 
-def validate_inputs(namespace) -> None:
+def validate_inputs(namespace, name_to_ignore=tuple()) -> None:
     """Adds missing Orange inputs by compaing the existing Orange
     inputs with the ewoks inputs."""
     if ORANGE_VERSION == ORANGE_VERSION.oasys_fork:
@@ -198,11 +201,18 @@ def validate_inputs(namespace) -> None:
             namespace["Inputs"] = Inputs
 
         _validate_signals(
-            namespace, "inputs", namespace["ewokstaskclass"].input_names()
+            namespace=namespace,
+            direction="inputs",
+            names=tuple(
+                filter(
+                    lambda name: name not in name_to_ignore,
+                    namespace["ewokstaskclass"].input_names(),
+                )
+            ),
         )
 
 
-def validate_outputs(namespace) -> None:
+def validate_outputs(namespace, name_to_ignore=tuple()) -> None:
     """Adds missing Orange outputs by compaing the existing Orange
     outputs with the ewoks outputs."""
     if ORANGE_VERSION == ORANGE_VERSION.oasys_fork:
@@ -224,7 +234,14 @@ def validate_outputs(namespace) -> None:
             namespace["Outputs"] = Outputs
 
         _validate_signals(
-            namespace, "outputs", namespace["ewokstaskclass"].output_names()
+            namespace=namespace,
+            direction="outputs",
+            names=tuple(
+                filter(
+                    lambda name: name not in name_to_ignore,
+                    namespace["ewokstaskclass"].output_names(),
+                )
+            ),
         )
 
 

--- a/src/ewoksorange/bindings/owwidgets.py
+++ b/src/ewoksorange/bindings/owwidgets.py
@@ -98,8 +98,14 @@ def prepare_OWEwoksWidgetclass(namespace, ewokstaskclass):
     namespace["default_inputs"] = Setting(dict(), schema_only=schema_only)
 
     # Add missing inputs and outputs as widget class attributes
-    owsignals.validate_inputs(namespace)
-    owsignals.validate_outputs(namespace)
+    owsignals.validate_inputs(
+        namespace,
+        name_to_ignore=namespace.get("_ewoks_inputs_to_hide_from_orange", tuple()),
+    )
+    owsignals.validate_outputs(
+        namespace,
+        name_to_ignore=namespace.get("_ewoks_outputs_to_hide_from_orange", tuple()),
+    )
 
 
 class _OWEwoksWidgetMetaClass(WidgetMetaClass):


### PR DESCRIPTION
***In GitLab by @payno on Nov 20, 2023, 10:29 GMT+1:***

close #31 

# result

interface before the PR![Screenshot_from_2023-11-20_09-36-08](https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/uploads/629c770383d98c38a9ef0b245e53a273/Screenshot_from_2023-11-20_09-36-08.png)
interface after the PR and adding the following to the widget

```
class MyEwoksOrangeWidget:
    ...
    _ewoks_inputs_to_hide_from_orange = (
        "__process__",
        "raw_projections_required",
        "raw_projections_each",
        "raw_darks_required",
        "raw_flats_required",
    )
```

![Screenshot_from_2023-11-20_10-37-21](https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/uploads/e1b41bc891b0ddd22ebfc978dbed608e/Screenshot_from_2023-11-20_10-37-21.png)

**Assignees:** @payno

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/150*