### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # CHANGELOG.md
 
-## 0.7.0 (unreleased)
+## 0.8.0 (unreleased)
+
+## 0.7.0
+
+Changes:
+
+- Task creation exception error log when non created by an upstream signal
+- Remove deprecated `pkg_resources` usage
+- Remove support for runtime installation of Orange add-ons and replace with
+  a hidden "ewokstest" widget category. This category is visible only when
+  the canvas is launched with `ewoks-canvas --with-examples`.
+- Provide Orange configuration of all supported Orange forks
+- Declare `orangecontrib` as an implicit namespace package
+- Provide a helper function `widget_discovery` to be used in add-ons that
+  need to avoid using `pkg_resources`
 
 ## 0.6.0
 

--- a/src/ewoksorange/__init__.py
+++ b/src/ewoksorange/__init__.py
@@ -9,4 +9,4 @@ from .oasys_patch import oasys_patch
 oasys_patch()
 patch_signal_manager()
 
-__version__ = "0.6.0"
+__version__ = "0.7.0rc"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 18, 2024, 14:05 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/162*