### PR TITLE
Fix get_default_input_value in OWEwoksBaseWidget

### DIFF
--- a/src/ewoksorange/bindings/owwidgets.py
+++ b/src/ewoksorange/bindings/owwidgets.py
@@ -246,10 +246,10 @@ class OWEwoksBaseWidget(OWWidget, metaclass=_OWEwoksWidgetMetaClass, **ow_build_
         self.set_dynamic_input(name, value)
 
     def get_default_input_value(self, name: str, default=None) -> Any:
-        return self._ewoks_default_inputs.get(name, default=default)
+        return self._ewoks_default_inputs.get(name, default)
 
     def get_dynamic_input_value(self, name: str, default=None) -> Any:
-        return self.__dynamic_inputs.get(name, default=default)
+        return self.__dynamic_inputs.get(name, default)
 
     def get_task_output_value(self, name, default=missing_data.MISSING_DATA) -> Any:
         adict = self.get_task_outputs()


### PR DESCRIPTION
***In GitLab by @loichuder on Mar 25, 2024, 16:39 GMT+1:***

Calling `get_default_input_value` failed since `dict.get` does not allow keyword arguments:

```
>>> d = dict()
>>> d.get("a", default=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: dict.get() takes no keyword arguments
```

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/164*