### PR TITLE
Remove deprecated DirectoryOnly file mode in parameter form

### DIFF
--- a/src/ewoksorange/gui/parameterform.py
+++ b/src/ewoksorange/gui/parameterform.py
@@ -609,7 +609,8 @@ class ParameterForm(QtWidgets.QWidget):
         else:
             directory = self.get_parameter_value(name)
         dialog = QtWidgets.QFileDialog(self)
-        dialog.setFileMode(QtWidgets.QFileDialog.DirectoryOnly)
+        dialog.setFileMode(QtWidgets.QFileDialog.Directory)
+        dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly)
         if directory:
             dialog.setDirectory(directory)
 


### PR DESCRIPTION
***In GitLab by @loichuder on Jun 19, 2024, 10:24 GMT+2:***

`DirectoryOnly` is obsolete since Qt 4.5 and is removed in Qt 6: https://doc.qt.io/qt-5/qfiledialog.html#FileMode-enum

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/177*