### PR TITLE
OWEwoksWidgetOneThread: add a get on the task executor. Especially useful for tests.

### DIFF
--- a/src/ewoksorange/bindings/owwidgets.py
+++ b/src/ewoksorange/bindings/owwidgets.py
@@ -605,6 +605,10 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self.__task_executor.finished.emit()
 
     @property
+    def task_executor(self):
+        return self.__task_executor
+
+    @property
     def task_succeeded(self) -> Optional[bool]:
         return self.__task_executor.succeeded
 


### PR DESCRIPTION
***In GitLab by @payno on Jun 14, 2024, 13:40 GMT+2:***



**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/176*