### PR TITLE
Bump to version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## (unreleased)
 
+## 0.8.0
+
+Changes:
+
+- `OWEwoksWidgetOneThread`, `OWEwoksWidgetOneThreadPerRun`, `OWEwoksWidgetWithTaskStack`: new method `cancel_running_task` to cancel the current task
+- Usage with Python 3.6 and 3.7 is deprecated. These versions will not be supported by the next major release.
+
 ## 0.7.2
 
 Bug fixes:

--- a/src/ewoksorange/__init__.py
+++ b/src/ewoksorange/__init__.py
@@ -9,4 +9,4 @@ from .oasys_patch import oasys_patch
 oasys_patch()
 patch_signal_manager()
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 15, 2024, 21:12 GMT+2:***



**Assignees:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/186*