### PR TITLE
Fix OWEwoksWidgetOneThreadPerRun: fix '__disconnect_all_task_executors'

### DIFF
--- a/src/ewoksorange/bindings/owwidgets.py
+++ b/src/ewoksorange/bindings/owwidgets.py
@@ -649,7 +649,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.__task_executors: dict[int, ThreadedTaskExecutor] = dict()
+        self.__task_executors: dict[int, tuple[ThreadedTaskExecutor, bool]] = dict()
         self.__last_output_variables = dict()
         self.__last_task_succeeded = None
         self.__last_task_done = None


### PR DESCRIPTION
***In GitLab by @payno on Oct 28, 2024, 11:43 GMT+1:***



**Assignees:** @payno

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/187*