### PR TITLE
CI: fix test-3.8-orange

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,12 +12,12 @@ test-3.8-orange:
   extends: .test-3.8_glx
   script:
     - echo PIP_INSTALL_OPTIONS $PIP_INSTALL_OPTIONS
-    - python -m pip install Orange3 # https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/issues/47
+    - python -m pip install Orange3 --prefer-binary # https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/issues/47, https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/issues/55
     - python -m pip install $QT_API $PIP_INSTALL_OPTIONS .[test,orange]
     - !reference [.test-3.8_glx, script]
   variables:
     JUPYTER_PLATFORM_DIRS: 1
-    PYTEST_WARNINGS: "-W error ${IGNORE_WARNINGS}"
+    PYTEST_WARNINGS: ""
 
 test-3.10-orange-win:
   extends: .test-3.10_glx-win


### PR DESCRIPTION
***In GitLab by @payno on Jun 6, 2025, 10:36 GMT+2:***

Starting from a fresh mamba python 3.8 I was able to reproduce [the issue](https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/issues/55)
```
(python38) payno@PCpayno:~/Downloads$ pip list
Package    Version
---------- -------
pip        24.3.1
setuptools 75.3.0
wheel      0.45.1

(python38) payno@PCpayno:~/Downloads$ pip install Orange3
Collecting Orange3
  Downloading Orange3-3.37.0.tar.gz (3.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.7/3.7 MB 8.3 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [454 lines of output]
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
                  yi, xi = int(y[i]), int(x[i])
                  cont[yi, xi] += 1
          return cont
      
      def find_threshold_entropy(const double[:] x, const double[:] y,
                                 const np.intp_t[:] idx,
                                       ^
...
```

I can't pinpoint the core issue. I tried some older Cython version....
Given that we are discussing about python 3.8 I opted to add the '--prefer-binary' option.
However the versions with python 3.8 binary support are outdated and have issues with [deprecation warning](https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/jobs/1703173) of the API...

As I see our options are:

* a. keep the 'bug fix' as it is. Less than ideal as it will ignores some errors and uses old version of the lib
* b. move test to more recent version (and probably drop 3.8. But we already had this discussion I think)
* c. invest more time identifying the origin of the bug. But most likely the result would involve lib breaking with python 3.8 which is abandon and will either end in a dead-end or be time consuming.

Looking with the current 'dynamic' I would say we will go for a. (but I would be in favor of b)

**Assignees:** @payno

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/224*