### PR TITLE
bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-Drop support for Python 3.6 and 3.7
+## 1.2.0
+
+Changes:
+
+- Drop support for Python 3.6 and 3.7
+- `ows_to_ewoks`: load default inputs even when the orange widget does not exist.
+- `OWEwoksWidgetOneThreadPerRun`: ensure every execution result is used and not
+  ignored because of a new execution.
 
 ## 1.1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=46.4"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "ewoksorange"
-version = "1.1.0"
+version = "1.2.0"
 authors = [{ name = "ESRF", email = "dau-pydev@esrf.fr" }]
 description = "Orange binding for Ewoks"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 10, 2025, 09:53 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/226*