### PR TITLE
Improve pkg meta

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,17 @@ test-3.8-orange:
     JUPYTER_PLATFORM_DIRS: 1
     PYTEST_WARNINGS: ""
 
+test-3.8-orange-old:
+  extends: .test-3.8_glx
+  script:
+    - echo PIP_INSTALL_OPTIONS $PIP_INSTALL_OPTIONS
+    - python -m pip install Orange3 --prefer-binary # https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/issues/47, https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/issues/55
+    - python -m pip install $QT_API $PIP_INSTALL_OPTIONS .[test,orange] "orange-canvas-core<0.2a"
+    - !reference [.test-3.8_glx, script]
+  variables:
+    JUPYTER_PLATFORM_DIRS: 1
+    PYTEST_WARNINGS: ""
+
 test-3.10-orange-win:
   extends: .test-3.10_glx-win
   script:
@@ -59,7 +70,7 @@ test-3.8-oasys:
   script:
     - echo PIP_INSTALL_OPTIONS $PIP_INSTALL_OPTIONS
     - python -m pip install oasys1 AnyQt
-    - python -m pip install $QT_API $PIP_INSTALL_OPTIONS ewokscore importlib-resources pytest
+    - python -m pip install $QT_API $PIP_INSTALL_OPTIONS ewokscore pytest
     - python -m pip install --no-deps .
     - python -m pip list
     - python -m pytest -v .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "orange-canvas-core",
     "orange-widget-base",
     "importlib-resources; python_version<'3.9'",
+    "importlib-metadata; python_version<'3.9'",
+    "packaging",
 ]
 
 [project.urls]

--- a/src/ewoksorange/canvas/config.py
+++ b/src/ewoksorange/canvas/config.py
@@ -1,6 +1,10 @@
 """Copy parts of Orange.canvas.config to be used when Orange3 is not installed."""
 
+from typing import Tuple
+
+from .. import pkg_meta
 from ..orange_version import ORANGE_VERSION
+
 
 if ORANGE_VERSION == ORANGE_VERSION.oasys_fork:
     from oasys.canvas.conf import oasysconf as _Config
@@ -12,39 +16,42 @@ else:
     from orangewidget.workflow.config import Config as _Config
     from orangewidget.workflow.config import WIDGETS_ENTRY  # "orange.widgets"
 
-from ..pkg_meta import iter_entry_points
 
 EXAMPLE_WORKFLOWS_ENTRY = WIDGETS_ENTRY + ".tutorials"
 
 
 class Config(_Config):
     @staticmethod
-    def widgets_entry_points():
-        """Return an `EntryPoint` iterator for all WIDGETS_ENTRY entry points."""
-        # Ensure the 'this' distribution's ep is the first. iter_entry_points
-        # yields them in unspecified order.
+    def widgets_entry_points() -> Tuple[pkg_meta.EntryPoint]:
+        """Return all WIDGETS_ENTRY entry points."""
+        # Ensure 'this' distribution's ep is the first.
+        # `entry_points` returns them in unspecified order.
         from orangecontrib.ewokstest import is_ewokstest_category_enabled
 
-        for ep in iter_entry_points(group=WIDGETS_ENTRY):
+        eps = list()
+        for ep in pkg_meta.entry_points(WIDGETS_ENTRY):
             if (
                 _get_ep_module(ep) == "orangecontrib.ewokstest"
                 and not is_ewokstest_category_enabled()
             ):
                 continue
-            yield ep
+            eps.append(ep)
+        return tuple(eps)
 
     @staticmethod
-    def examples_entry_points():
-        """Return an `EntryPoint` iterator for all EXAMPLE_WORKFLOWS_ENTRY entry points."""
+    def examples_entry_points() -> Tuple[pkg_meta.EntryPoint]:
+        """Return all EXAMPLE_WORKFLOWS_ENTRY entry points."""
         from orangecontrib.ewokstest import is_ewokstest_category_enabled
 
-        for ep in iter_entry_points(group=EXAMPLE_WORKFLOWS_ENTRY):
+        eps = list()
+        for ep in pkg_meta.entry_points(EXAMPLE_WORKFLOWS_ENTRY):
             if (
                 _get_ep_module(ep) == "orangecontrib.ewokstest.tutorials"
                 and not is_ewokstest_category_enabled()
             ):
                 continue
-            yield ep
+            eps.append(ep)
+        return tuple(eps)
 
     tutorials_entry_points = examples_entry_points
 

--- a/src/ewoksorange/orange_version.py
+++ b/src/ewoksorange/orange_version.py
@@ -1,15 +1,30 @@
 from enum import Enum
+import importlib.metadata
 
 _OrangeVersion = Enum("OrangeVersion", "latest_orange oasys_fork latest_orange_base")
 
-try:
-    import oasys.widgets  # noqa F401
+_DISTRIBUTION_TO_VERSION = {
+    "oasys1": _OrangeVersion.oasys_fork,
+    "oasys-canvas-core": _OrangeVersion.oasys_fork,
+    "orange3": _OrangeVersion.latest_orange,
+    "orange-canvas-core": _OrangeVersion.latest_orange_base,
+}
 
-    ORANGE_VERSION = _OrangeVersion.oasys_fork
-except ImportError:
+for distribution, version in _DISTRIBUTION_TO_VERSION.items():
     try:
-        import Orange  # noqa F401
-    except ImportError:
-        ORANGE_VERSION = _OrangeVersion.latest_orange_base
+        _ = importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        continue
     else:
-        ORANGE_VERSION = _OrangeVersion.latest_orange
+        ORANGE_VERSION = version
+        break
+else:
+    raise importlib.metadata.PackageNotFoundError(
+        "No compatible Orange distributions found."
+    )
+
+# Fix test_cancel_current_task_in_task_executor_queue failures:
+if ORANGE_VERSION == ORANGE_VERSION.oasys_fork:
+    import oasys.widgets  # noqa F401
+elif ORANGE_VERSION == ORANGE_VERSION.latest_orange:
+    import Orange  # noqa F401

--- a/src/ewoksorange/registration.py
+++ b/src/ewoksorange/registration.py
@@ -4,7 +4,7 @@ Widget and example discovery is done from these entry-points.
 """
 
 import logging
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from . import pkg_meta
 from .orange_version import ORANGE_VERSION
@@ -124,15 +124,17 @@ def register_owwidget(
 def get_owwidget_descriptions():
     """Do not include native orange widgets"""
     disc = _local_widget_discovery_object()
-    disc.run(_iter_entry_points(WIDGETS_ENTRY))
+    disc.run(_entry_points(WIDGETS_ENTRY))
     return disc.registry.widgets()
 
 
-def _iter_entry_points(group):
+def _entry_points(group: str) -> Tuple[pkg_meta.EntryPoint]:
     """Do not include native orange entry points"""
-    for ep in pkg_meta.iter_entry_points(group):
+    eps = list()
+    for ep in pkg_meta.entry_points(group):
         if pkg_meta.get_distribution_name(ep.dist).lower() != NATIVE_WIDGETS_PROJECT:
-            yield ep
+            eps.append(ep)
+    return tuple(eps)
 
 
 def _global_widget_discovery_objects() -> List[WidgetDiscovery]:


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 2, 2025, 24:29 GMT+2:***

Instead trying to import things and capturing `ImportError` this MR proposes to rely on the presence or absence of specific distribution and their version. We did the same refactoring for `blissoda` and `ewoksdata`. This is the last project. Lets never do this again!

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/227*