### PR TITLE
ci: suppress matplotlib warnings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,9 @@ variables:
   WARNING1: "ignore::ResourceWarning:orangecanvas.utils.localization" # https://github.com/biolab/orange-canvas-core/pull/312
   WARNING2: "ignore::DeprecationWarning:orangecanvas.utils.localization"
   WARNING3: "ignore::DeprecationWarning:orangecanvas.utils.localization.si"
-  IGNORE_WARNINGS: "-W ${WARNING1} -W ${WARNING2} -W ${WARNING3}"
+  WARNING4: "ignore::DeprecationWarning:matplotlib._fontconfig_pattern"  # https://github.com/matplotlib/matplotlib/issues/30617
+  WARNING5: "ignore::DeprecationWarning:matplotlib._mathtext"
+  IGNORE_WARNINGS: "-W ${WARNING1} -W ${WARNING2} -W ${WARNING3} -W ${WARNING4} -W ${WARNING5}"
 
 test-3.8-orange:
   extends: .test-3.8_glx


### PR DESCRIPTION
***In GitLab by @woutdenolf on Sep 29, 2025, 16:08 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/237*