### PR TITLE
fix: get Ewoks task from widget name for nodes with no widget

### DIFF
--- a/src/orangecontrib/ewoksnowidget/__init__.py
+++ b/src/orangecontrib/ewoksnowidget/__init__.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 from ewokscore import Task
 from ewokscore import TaskWithProgress
+from ewoksutils.import_utils import qualname
 
 from ewoksorange import registration
 from ewoksorange.bindings import OWEwoksWidgetNoThread
@@ -51,7 +52,7 @@ def default_owwidget_class(task_class: Task) -> Tuple[OWEwoksBaseWidget, str]:
         basecls = OWEwoksWidgetNoThread
 
     class DefaultOwWidget(basecls, ewokstaskclass=task_class):
-        name = f"DefaultOwWidget({task_class.__name__})"
+        name = qualname(task_class)
         description = f"Orange widget is missing for Ewoks task {task_class.__name__}"
         icon = "icons/nowidget.svg"
         want_main_area = False


### PR DESCRIPTION
***In GitLab by @CammilleCC on Oct 17, 2025, 12:31 GMT+2:***

This PR aims to recreate the the dynamic Ewoks class from the widget by using the widget name to import the Ewoks class.

Unfortunately, opening the generated OWS file via `ewoks-canvas` still fails. 

Closes #62

**Assignees:** @CammilleCC

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/245*