### PR TITLE
ewoksnowidget cleanup utility and usage in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `orangecontrib.ewoksnowidget.global_cleanup_ewoksnowidget` removes all dynamically generated widget
+  declarations from the `orangecontrib.ewoksnowidget` Orange add-on. Used by pytest fixture `qtapp`.
+
 ## [2.0.1] - 2025-09-22
 
 ### Fixed

--- a/src/ewoksorange/registration.py
+++ b/src/ewoksorange/registration.py
@@ -124,9 +124,9 @@ def register_owwidget(
 
 def get_owwidget_descriptions():
     """Do not include native orange widgets"""
-    disc = _local_widget_discovery_object()
-    disc.run(_entry_points(WIDGETS_ENTRY))
-    return disc.registry.widgets()
+    discovery = _temporary_widget_discovery_object()
+    discovery.run(_entry_points(WIDGETS_ENTRY))
+    return discovery.registry.widgets()
 
 
 def _entry_points(group: str) -> Tuple[pkg_meta.EntryPoint]:
@@ -142,7 +142,7 @@ def _global_widget_discovery_objects() -> List[WidgetDiscovery]:
     return [WidgetDiscovery(reg) for reg in _global_registry_objects()]
 
 
-def _local_widget_discovery_object() -> WidgetDiscovery:
+def _temporary_widget_discovery_object() -> WidgetDiscovery:
     return WidgetDiscovery(WidgetRegistry())
 
 

--- a/src/ewoksorange/tests/conftest.py
+++ b/src/ewoksorange/tests/conftest.py
@@ -9,6 +9,7 @@ from ewoksorange.bindings.qtapp import get_all_qtwidgets
 from ewoksorange.bindings.qtapp import qtapp_context
 from ewoksorange.canvas.handler import OrangeCanvasHandler
 from ewoksorange.orange_version import ORANGE_VERSION
+from orangecontrib.ewoksnowidget import global_cleanup_ewoksnowidget
 from orangecontrib.ewokstest import enable_ewokstest_category
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ def qtapp():
         assert app is not None
         yield app
     collect_garbage(app)
+    global_cleanup_ewoksnowidget()
     global_cleanup_orange()
     global_cleanup_pytest()
     collect_garbage(app)

--- a/src/ewoksorange/tests/test_default_widget.py
+++ b/src/ewoksorange/tests/test_default_widget.py
@@ -9,7 +9,7 @@ class Dummy(Task, input_names=["a"], output_names=["b"]):
         self.outputs.b = self.inputs.a + 1
 
 
-def test_default_widgets(tmpdir, ewoks_orange_canvas):
+def test_default_widgets(tmp_path, ewoks_orange_canvas):
     nodes = [
         {
             "id": "task1",
@@ -34,7 +34,7 @@ def test_default_widgets(tmpdir, ewoks_orange_canvas):
 
     # Create an Orange workflows
     graph = {"graph": {"id": "test_graph"}, "nodes": nodes, "links": links}
-    destination = str(tmpdir / "ewoksgraph.ows")
+    destination = str(tmp_path / "ewoksgraph.ows")
     ewoks_to_ows(graph, destination)
 
     # Load and execute the orange workflow

--- a/src/orangecontrib/ewoksnowidget/__init__.py
+++ b/src/orangecontrib/ewoksnowidget/__init__.py
@@ -5,9 +5,9 @@ from ewokscore import TaskWithProgress
 from ewoksutils.import_utils import qualname
 
 from ewoksorange import registration
-from ewoksorange.bindings import OWEwoksWidgetNoThread
-from ewoksorange.bindings import OWEwoksWidgetOneThread
 from ewoksorange.bindings.owwidgets import OWEwoksBaseWidget
+from ewoksorange.bindings.owwidgets import OWEwoksWidgetNoThread
+from ewoksorange.bindings.owwidgets import OWEwoksWidgetOneThread
 
 from . import widgets
 
@@ -77,3 +77,15 @@ def default_owwidget_class(task_class: Task) -> Tuple[OWEwoksBaseWidget, str]:
 def widget_discovery(discovery):
     for widget_class in _DEFAULT_WIDGET_CLASSES.values():
         register_owwidget(widget_class, discovery_object=discovery)
+
+
+def global_cleanup_ewoksnowidget():
+    """Remove all widget declarations."""
+    # Note: the discovery object owns a widget registry which keeps references
+    # to all discovered widget classes. The widgets from `ewoksnowidget` are
+    # never registered with a global widget registry (so not visible in the
+    # widget panel in the canvas) so there is no need to remove the widgets
+    # from the registry used during discovery.
+    for widget_class in _DEFAULT_WIDGET_CLASSES.values():
+        delattr(widgets, widget_class.__name__)
+    _DEFAULT_WIDGET_CLASSES.clear()


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 18, 2025, 11:52 GMT+2:***

`orangecontrib.ewoksnowidget.global_cleanup_ewoksnowidget` removes all dynamically generated widget declarations from the `orangecontrib.ewoksnowidget` Orange add-on. Used by pytest fixture `qtapp`.

**Assignees:** @woutdenolf

**Reviewers:** @CammilleCC

**Approved by:** @CammilleCC

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/246*