### PR TITLE
Resolve "Memory leak in Orange and ewoks-orange ?"

### DIFF
--- a/src/ewoksorange/gui/orange_utils/signal_manager.py
+++ b/src/ewoksorange/gui/orange_utils/signal_manager.py
@@ -1,3 +1,4 @@
+import weakref
 from typing import Any
 
 from ...orange_version import ORANGE_VERSION
@@ -168,7 +169,7 @@ class SignalManagerWithOutputTracking:
     """
 
     def __init__(self, *args, **kwargs):
-        self._widget_states = dict()
+        self._widget_states = weakref.WeakKeyDictionary()
         super().__init__(*args, **kwargs)
 
     def _get_widget_state(self, owwidget) -> _OwWidgetSignalState:


### PR DESCRIPTION
***In GitLab by @maxenceprog on Dec 19, 2025, 09:33 GMT+1:***

Closes #69 

Tested with main branch of orange-widget-base + darfix 4.2 -> The memory leak issue on widget deletion is solved

**Assignees:** @maxenceprog

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/259*