### PR TITLE
Progress bar : Also enabled with orange-widget-base dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.8"
 dependencies = [
     "ewokscore >=4.0.1",
     "orange-canvas-core",
-    "orange-widget-base",
+    "orange-widget-base>=4.13.0",
     "importlib-resources; python_version<'3.9'",
     "importlib-metadata; python_version<'3.9'",
     "packaging",

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -10,7 +10,6 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 
-from ...orange_version import ORANGE_VERSION
 from ..concurrency.queued import TaskExecutorQueue
 from ..concurrency.threaded import ThreadedTaskExecutor
 from ..qt_utils.progress import QProgress
@@ -18,13 +17,6 @@ from .base import OWEwoksBaseWidget
 from .meta import ow_build_opts
 
 _logger = logging.getLogger(__name__)
-
-if ORANGE_VERSION == ORANGE_VERSION.oasys_fork:
-    has_progress_bar = True
-elif ORANGE_VERSION == ORANGE_VERSION.latest_orange:
-    has_progress_bar = True
-else:
-    has_progress_bar = False
 
 
 class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
@@ -40,18 +32,14 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
         Initialize threaded base internals, including optional progress object.
         """
         super().__init__(*args, **kwargs)
-        if has_progress_bar:
-            self.__taskProgress = QProgress()
-            self.__taskProgress.sigProgressChanged.connect(self.__onProgressChanged)
-        else:
-            self.__taskProgress = None
+        self.__taskProgress = QProgress()
+        self.__taskProgress.sigProgressChanged.connect(self.__onProgressChanged)
 
     def onDeleteWidget(self):
         """
         Clean up progress connections and task executors on widget deletion.
         """
-        if has_progress_bar:
-            self.__taskProgress.sigProgressChanged.disconnect(self.__onProgressChanged)
+        self.__taskProgress.sigProgressChanged.disconnect(self.__onProgressChanged)
         self._cleanup_task_executor()
         super().onDeleteWidget()
 
@@ -89,13 +77,11 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
 
     def __ewoks_task_init(self):
         """Internal: initialize progress UI if available."""
-        if has_progress_bar:
-            self.progressBarInit()
+        self.progressBarInit()
 
     def __ewoks_task_finished(self):
         """Internal: finalize progress UI and notify output change."""
-        if has_progress_bar:
-            self.progressBarFinished()
+        self.progressBarFinished()
         self._output_changed()
 
     def _get_task_arguments(self):


### PR DESCRIPTION
***In GitLab by @maxenceprog on Jan 15, 2026, 14:18 GMT+1:***

Enable Progress bar also with orange-widget-base

I put a minimum version for orange-widget-base because below 4.13 import like 

`from orangewidget.utils.signals import notify_input_helper` failed

See https://redirect.github.com/biolab/orange-widget-base/commit/0c41feb1839afa313aba3f2e3591be0ea69e1111

**Assignees:** @maxenceprog

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/263*