### PR TITLE
Fix Orange signals not added to widget Inputs

### DIFF
--- a/src/ewoksorange/gui/orange_utils/_signals.py
+++ b/src/ewoksorange/gui/orange_utils/_signals.py
@@ -259,6 +259,9 @@ def validate_signals(
     signal_container_class = namespace[signal_container_name]
     signals_dict = _get_signal_ewoks_dict(signal_container_class)
 
+    # Concatenate Ewoks task-only IO and Orange signals to get the complete list
+    ewoks_names = tuple(list(ewoks_names) + list(signals_dict.keys()))
+
     # Validate signal container
     signals_attrs = list()
     new_signals_class = False

--- a/src/ewoksorange/tests/test_tasks.py
+++ b/src/ewoksorange/tests/test_tasks.py
@@ -11,3 +11,8 @@ def test_sumtask_task():
 def test_sumtask_widget(qtapp):
     result = execute_task(OWSumTask, inputs={"a": 1, "b": 2})
     assert result == {"result": 3}
+
+
+def test_orange_only_input(qtapp):
+    widget = OWSumTask()
+    assert widget.Inputs.c

--- a/src/orangecontrib/ewoksdemo/sumtask.py
+++ b/src/orangecontrib/ewoksdemo/sumtask.py
@@ -17,6 +17,7 @@ class OWSumTask(IntegerAdderMixin, OWEwoksWidgetOneThread, ewokstaskclass=SumTas
     class Inputs:
         a = Input("A", object)
         b = Input("B", object)
+        c = Input("C", int)
 
     class Outputs:
         result = Output("A + B", object)


### PR DESCRIPTION
***In GitLab by @loichuder on Jan 16, 2026, 16:14 GMT+1:***

Fix #78 

Credit goes to @payno who noticed that Orange signals were not added to the `Inputs` container of the widget.

I added a test to prevent further regression.

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/266*