### PR TITLE
Resolve "Better error message for missing signals"

### DIFF
--- a/src/ewoksorange/gui/orange_utils/_signals.py
+++ b/src/ewoksorange/gui/orange_utils/_signals.py
@@ -200,7 +200,9 @@ def signal_orange_to_ewoks_name(
     for ewoks_or_attr_name, signal in signal_dict.items():
         if signal.name == orangename:
             return ewoks_or_attr_name
-    raise RuntimeError(f"{orangename} is not a signal of {signal_container}")
+    raise RuntimeError(
+        f"{orange_widget.__name__} does not have a signal {orangename!r} in {signal_container.__name__!r}"
+    )
 
 
 def get_signal(


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 12, 2026, 10:42 GMT+1:***

Closes #84 

Improve error message

```
RuntimeError: image_stacks is not a signal of <class 'ewoksorange.gui.orange_utils._signals.Outputs'>
```

by

```
RuntimeError: OWSelectNXdataImageStacks does not have a signal 'image_stacks' in 'Outputs'
```

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/275*