### PR TITLE
ewoksOrange task processing: move to Future.

### DIFF
--- a/src/ewoksorange/bindings/taskexecuter.py
+++ b/src/ewoksorange/bindings/taskexecuter.py
@@ -1,6 +1,7 @@
 import warnings
 
 from ..gui.concurrency.base import TaskExecutor  # noqa F401
+from ..gui.concurrency.threaded import MultiThreadedTaskExecutor  # noqa F401
 from ..gui.concurrency.threaded import ThreadedTaskExecutor  # noqa F401
 
 warnings.warn(

--- a/src/ewoksorange/gui/concurrency/_Executor.py
+++ b/src/ewoksorange/gui/concurrency/_Executor.py
@@ -1,0 +1,10 @@
+class CancellableExecutor:
+    def _cancel_future(self, future) -> bool:
+        """Cancel a pending future"""
+        raise NotImplementedError("Base class")
+
+
+class AbortableExecutor:
+    def _abort_future(self, future) -> bool:
+        """Abort a running future"""
+        raise NotImplementedError("Base class")

--- a/src/ewoksorange/gui/concurrency/_future.py
+++ b/src/ewoksorange/gui/concurrency/_future.py
@@ -38,7 +38,6 @@ class TaskFuture(_Future):
         if self.done():
             return False
         if self.executor:
-            return self.executor._cancel_future(self)
-        # this should never happen but safer to log this us case
-        _logger.error("executor has been deleted. Unable to cancel.")
-        return False
+            self.executor._cancel_future(self)
+
+        return super().cancel()

--- a/src/ewoksorange/gui/concurrency/_future.py
+++ b/src/ewoksorange/gui/concurrency/_future.py
@@ -1,0 +1,37 @@
+import logging
+from concurrent.futures import Future as _Future
+import weakref
+from .base import TaskExecutionID
+
+_logger = logging.getLogger(__name__)
+
+
+class ExecutorFutureHandler:
+    """Class allowing handling of 'TaskFuture'"""
+
+    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
+        raise NotImplementedError("Base class")
+
+
+class TaskFuture(_Future):
+    """Implementation of Future for tasks and 'ExecutorFutureHandler'"""
+
+    def __init__(self, task_exec_id: str, executor: ExecutorFutureHandler, **kwargs):
+        super().__init__()
+
+        self._executor = weakref.ref(executor)
+        self.task_kwargs = {}
+        self.task_exec_id = task_exec_id
+
+    @property
+    def executor(self) -> ExecutorFutureHandler | None:
+        return self._executor()
+
+    def cancel(self) -> bool:
+        if self.done():
+            return False
+        if self.executor:
+            return self.executor._cancel_future(self)
+        # this should never happen but safer to log this us case
+        _logger.error("executor has been deleted. Unable to cancel.")
+        return False

--- a/src/ewoksorange/gui/concurrency/_future.py
+++ b/src/ewoksorange/gui/concurrency/_future.py
@@ -1,23 +1,30 @@
 import logging
-from concurrent.futures import Future as _Future
 import weakref
-from .base import TaskExecutionID
+from concurrent.futures import Future as _Future
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import TaskExecutionID
 
 _logger = logging.getLogger(__name__)
 
 
 class ExecutorFutureHandler:
-    """Class allowing handling of 'TaskFuture'"""
+    """Define internal API to cancel a future."""
 
-    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
+    def _cancel_future(self, future: TaskFuture) -> None:
         raise NotImplementedError("Base class")
 
 
 class TaskFuture(_Future):
     """Implementation of Future for tasks and 'ExecutorFutureHandler'"""
 
-    def __init__(self, task_exec_id: str, executor: ExecutorFutureHandler, **kwargs):
+    def __init__(
+        self, task_exec_id: TaskExecutionID, executor: ExecutorFutureHandler, **kwargs
+    ):
         super().__init__()
+        if not isinstance(executor, ExecutorFutureHandler):
+            raise TypeError
 
         self._executor = weakref.ref(executor)
         self.task_kwargs = {}

--- a/src/ewoksorange/gui/concurrency/_future.py
+++ b/src/ewoksorange/gui/concurrency/_future.py
@@ -1,4 +1,3 @@
-import logging
 import weakref
 from concurrent.futures import Future as _Future
 from typing import TYPE_CHECKING
@@ -6,13 +5,16 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .base import TaskExecutionID
 
-_logger = logging.getLogger(__name__)
-
 
 class ExecutorFutureHandler:
     """Define internal API to cancel a future."""
 
-    def _cancel_future(self, future: TaskFuture) -> None:
+    def _cancel_future(self, future: TaskFuture) -> bool:
+        """Cancel a pending future"""
+        raise NotImplementedError("Base class")
+
+    def _abort_future(self, future: TaskFuture) -> bool:
+        """Abort a running future"""
         raise NotImplementedError("Base class")
 
 
@@ -35,9 +37,16 @@ class TaskFuture(_Future):
         return self._executor()
 
     def cancel(self) -> bool:
+        # The Future 'cancel' API only works if the start hasn't cancel yet...
         if self.done():
             return False
-        if self.executor:
-            self.executor._cancel_future(self)
-
+        if not self.executor:
+            return False
+        self.executor._cancel_future(self)
         return super().cancel()
+
+    def abort(self) -> bool:
+        if not self.executor:
+            return False
+        res = self.executor._abort_future(self)
+        return res

--- a/src/ewoksorange/gui/concurrency/_future.py
+++ b/src/ewoksorange/gui/concurrency/_future.py
@@ -1,39 +1,28 @@
+from typing import TYPE_CHECKING
 import weakref
 from concurrent.futures import Future as _Future
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .base import TaskExecutionID
-
-
-class ExecutorFutureHandler:
-    """Define internal API to cancel a future."""
-
-    def _cancel_future(self, future: TaskFuture) -> bool:
-        """Cancel a pending future"""
-        raise NotImplementedError("Base class")
-
-    def _abort_future(self, future: TaskFuture) -> bool:
-        """Abort a running future"""
-        raise NotImplementedError("Base class")
 
 
 class TaskFuture(_Future):
     """Implementation of Future for tasks and 'ExecutorFutureHandler'"""
 
     def __init__(
-        self, task_exec_id: TaskExecutionID, executor: ExecutorFutureHandler, **kwargs
+        self,
+        task_exec_id: "TaskExecutionID",
+        executor,
+        **kwargs,
     ):
         super().__init__()
-        if not isinstance(executor, ExecutorFutureHandler):
-            raise TypeError
 
         self._executor = weakref.ref(executor)
         self.task_kwargs = {}
         self.task_exec_id = task_exec_id
 
     @property
-    def executor(self) -> ExecutorFutureHandler | None:
+    def executor(self):
         return self._executor()
 
     def cancel(self) -> bool:

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -7,6 +7,8 @@ from typing import TypeAlias
 from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 from ewokscore.task import TaskInputError
+from ._future import TaskFuture
+from concurrent.futures import InvalidStateError
 
 _logger = logging.getLogger(__name__)
 
@@ -35,24 +37,30 @@ class TaskExecutor:
             else:
                 _logger.info(f"task initialization failed: {e}")
 
-    def execute_task(self) -> TaskExecutionID:
+    def execute_task(self) -> TaskFuture:
         """
         Execute the task and return a tuple indicating success of the submission and the execution ID.
         """
-        if not self.has_task:
-            return str(
+        future = TaskFuture(
+            task_exec_id=str(
                 uuid.uuid4()
-            )  # Return a dummy TaskExecutionID since we couldn't create the task
+            ),  # Use a dummy TaskExecutionID since we couldn't create the task)
+            executor=self,
+        )
+        if not self.has_task:
+            # if no task defined this mean that initialization has failed.
+            future.set_exception(InvalidStateError("Task not defined."))
+            return future
+
         try:
             self.__task.execute()
         except Exception as e:
             _logger.error(f"task failed: {e}", exc_info=True)
-            return str(
-                uuid.uuid4()
-            )  # Return a dummy TaskExecutionID since we couldn't create the task
-        return str(
-            uuid.uuid4()
-        )  # Return a dummy TaskExecutionID since we couldn't create the task
+            future.set_exception(exception=e)
+        else:
+            # To be discussed. What should be the result ? output_values
+            future.set_result(self.__task.output_values)
+        return future
 
     @property
     def has_task(self) -> bool:

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -59,7 +59,9 @@ class TaskExecutor(ExecutorFutureHandler):
             _logger.error(f"task failed: {e}", exc_info=True)
             future.set_exception(exception=e)
         else:
-            future.set_result(self.__task.output_values)
+            if not self.__task.cancelled:
+                # TODO: investigate, this enter in conflict in the case of the "TaskExecutorQueue" setting result is called twice.
+                future.set_result(self.__task.get_output_values())
         return future
 
     @property
@@ -99,11 +101,10 @@ class TaskExecutor(ExecutorFutureHandler):
     def current_task(self) -> Optional[Task]:
         return self.__task
 
-    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
-        pass
+    def _cancel_future(self, future: TaskFuture) -> bool:
+        raise NotImplementedError
+        return False
 
-    def cancel_all_tasks(self) -> None:
-        pass
-
-    def _cancel_future(self, future: TaskFuture):
-        pass
+    def _abort_future(self, future: TaskFuture) -> bool:
+        raise NotImplementedError
+        return False

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -91,7 +91,7 @@ class TaskExecutor:
     def current_task(self) -> Optional[Task]:
         return self.__task
 
-    def cancel_task(self, task_id: TaskExecutionID) -> None:
+    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         raise NotImplementedError("Task cancellation is not implemented yet")
 
     def cancel_all_tasks(self) -> None:

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -34,18 +34,18 @@ class TaskExecutor:
             else:
                 _logger.info(f"task initialization failed: {e}")
 
-    def execute_task(self) -> tuple[bool, TaskExecutionID]:
+    def execute_task(self) -> TaskExecutionID:
         """
         Execute the task and return a tuple indicating success of the submission and the execution ID.
         """
         if not self.has_task:
-            return False, ""
+            return ""
         try:
             self.__task.execute()
         except Exception as e:
             _logger.error(f"task failed: {e}", exc_info=True)
-            return True, ""
-        return True, ""
+            return ""
+        return ""
 
     @property
     def has_task(self) -> bool:
@@ -84,7 +84,7 @@ class TaskExecutor:
     def current_task(self) -> Optional[Task]:
         return self.__task
 
-    def cancel_task(self, task_id) -> None:
+    def cancel_task(self, task_id: TaskExecutionID) -> None:
         raise NotImplementedError("Task cancellation is not implemented yet")
 
     def cancel_all_tasks(self) -> None:

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -1,5 +1,5 @@
-import uuid
 import logging
+import uuid
 from typing import Optional
 from typing import Type
 from typing import TypeAlias

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -1,12 +1,15 @@
 import logging
 from typing import Optional
 from typing import Type
+from typing import TypeAlias
 
 from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 from ewokscore.task import TaskInputError
 
 _logger = logging.getLogger(__name__)
+
+TaskExecutionID: TypeAlias = str
 
 
 class TaskExecutor:
@@ -31,13 +34,18 @@ class TaskExecutor:
             else:
                 _logger.info(f"task initialization failed: {e}")
 
-    def execute_task(self) -> None:
+    def execute_task(self) -> tuple[bool, TaskExecutionID]:
+        """
+        Execute the task and return a tuple indicating success of the submission and the execution ID.
+        """
         if not self.has_task:
-            return
+            return False, ""
         try:
             self.__task.execute()
         except Exception as e:
             _logger.error(f"task failed: {e}", exc_info=True)
+            return True, ""
+        return True, ""
 
     @property
     def has_task(self) -> bool:
@@ -75,3 +83,9 @@ class TaskExecutor:
     @property
     def current_task(self) -> Optional[Task]:
         return self.__task
+
+    def cancel_task(self, task_id) -> None:
+        raise NotImplementedError("Task cancellation is not implemented yet")
+
+    def cancel_all_tasks(self) -> None:
+        raise NotImplementedError("Task cancellation is not implemented yet")

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -92,7 +92,7 @@ class TaskExecutor:
         return self.__task
 
     def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
-        raise NotImplementedError("Task cancellation is not implemented yet")
+        pass
 
     def cancel_all_tasks(self) -> None:
-        raise NotImplementedError("Task cancellation is not implemented yet")
+        pass

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -1,3 +1,4 @@
+import uuid
 import logging
 from typing import Optional
 from typing import Type
@@ -39,13 +40,19 @@ class TaskExecutor:
         Execute the task and return a tuple indicating success of the submission and the execution ID.
         """
         if not self.has_task:
-            return ""
+            return str(
+                uuid.uuid4()
+            )  # Return a dummy TaskExecutionID since we couldn't create the task
         try:
             self.__task.execute()
         except Exception as e:
             _logger.error(f"task failed: {e}", exc_info=True)
-            return ""
-        return ""
+            return str(
+                uuid.uuid4()
+            )  # Return a dummy TaskExecutionID since we couldn't create the task
+        return str(
+            uuid.uuid4()
+        )  # Return a dummy TaskExecutionID since we couldn't create the task
 
     @property
     def has_task(self) -> bool:

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -7,15 +7,16 @@ from typing import TypeAlias
 from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 from ewokscore.task import TaskInputError
+
 from ._future import TaskFuture
-from concurrent.futures import InvalidStateError
 
 _logger = logging.getLogger(__name__)
 
 TaskExecutionID: TypeAlias = str
+from ._future import ExecutorFutureHandler
 
 
-class TaskExecutor:
+class TaskExecutor(ExecutorFutureHandler):
     """Create and execute an Ewoks task"""
 
     def __init__(self, ewokstaskclass: Type[Task]) -> None:
@@ -49,7 +50,7 @@ class TaskExecutor:
         )
         if not self.has_task:
             # if no task defined this mean that initialization has failed.
-            future.set_exception(InvalidStateError("Task not defined."))
+            future.set_exception(RuntimeError("Task not defined."))
             return future
 
         try:
@@ -58,7 +59,6 @@ class TaskExecutor:
             _logger.error(f"task failed: {e}", exc_info=True)
             future.set_exception(exception=e)
         else:
-            # To be discussed. What should be the result ? output_values
             future.set_result(self.__task.output_values)
         return future
 
@@ -103,4 +103,7 @@ class TaskExecutor:
         pass
 
     def cancel_all_tasks(self) -> None:
+        pass
+
+    def _cancel_future(self, future: TaskFuture):
         pass

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -8,15 +8,16 @@ from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 from ewokscore.task import TaskInputError
 
+# from ._future import TaskFuture
+from ._Executor import CancellableExecutor, AbortableExecutor
 from ._future import TaskFuture
 
 _logger = logging.getLogger(__name__)
 
 TaskExecutionID: TypeAlias = str
-from ._future import ExecutorFutureHandler
 
 
-class TaskExecutor(ExecutorFutureHandler):
+class TaskExecutor(CancellableExecutor, AbortableExecutor):
     """Create and execute an Ewoks task"""
 
     def __init__(self, ewokstaskclass: Type[Task]) -> None:
@@ -38,16 +39,19 @@ class TaskExecutor(ExecutorFutureHandler):
             else:
                 _logger.info(f"task initialization failed: {e}")
 
-    def execute_task(self) -> TaskFuture:
-        """
-        Execute the task and return a tuple indicating success of the submission and the execution ID.
-        """
-        future = TaskFuture(
+    def _build_future(self) -> TaskFuture:
+        return TaskFuture(
             task_exec_id=str(
                 uuid.uuid4()
             ),  # Use a dummy TaskExecutionID since we couldn't create the task)
             executor=self,
         )
+
+    def execute_task(self) -> TaskFuture:
+        """
+        Execute the task and return a tuple indicating success of the submission and the execution ID.
+        """
+        future = self._build_future()
         if not self.has_task:
             # if no task defined this mean that initialization has failed.
             future.set_exception(RuntimeError("Task not defined."))
@@ -101,10 +105,8 @@ class TaskExecutor(ExecutorFutureHandler):
     def current_task(self) -> Optional[Task]:
         return self.__task
 
-    def _cancel_future(self, future: TaskFuture) -> bool:
-        raise NotImplementedError
+    def _cancel_future(self, future) -> bool:
         return False
 
-    def _abort_future(self, future: TaskFuture) -> bool:
-        raise NotImplementedError
+    def _abort_future(self, future) -> bool:
         return False

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -144,9 +144,6 @@ class TaskExecutorQueue(QObject):
     def current_task(self):
         return self._task_executor.current_task
 
-    def __len__(self):
-        return len(self._task_queue) + (1 if self._current_task_exec_id else 0)
-
 
 class _ThreadedTaskExecutor(ThreadedTaskExecutor):
     """Processing thread with some information on callbacks to be executed"""

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import uuid
+
+from concurrent.futures import Future
 from collections import deque
-from typing import Any
 from typing import Deque
 from typing import Dict
 from typing import Iterable
@@ -30,9 +31,9 @@ class TaskExecutorQueue(QObject):
 
     def __init__(self, ewokstaskclass):
         super().__init__()
-        self._task_queue: Deque[TaskExecutionID] = deque()
+        self._task_queue: Deque[Future] = deque()
         """Queue storing task IDs in FIFO order"""
-        self._task_exec_ids: Dict[TaskExecutionID, Dict[str, Any]] = {}
+        self._task_futures: Dict[str:Future] = {}
         """Dictionary mapping task IDs to their keyword arguments"""
         self._current_task_exec_id: TaskExecutionID | None = None
         self._task_executor: ThreadedTaskExecutor = _ThreadedTaskExecutor(
@@ -44,28 +45,37 @@ class TaskExecutorQueue(QObject):
     def is_available(self) -> bool:
         return self._current_task_exec_id is None
 
-    def add(self, **kwargs) -> TaskExecutionID:
+    def add(self, **kwargs) -> Future:
         """Add a task `ewokstaskclass` execution request
 
         :return: Task identifier (UUID) that can be used to cancel the task
         """
         task_exec_id = str(uuid.uuid4())
-        self._task_exec_ids[task_exec_id] = kwargs
-        self._task_queue.append(task_exec_id)
+        future = Future(task_exec_id=task_exec_id, executor=self)
+
+        future.task_kwargs = kwargs
+
+        self._task_futures[task_exec_id] = future
+        self._task_queue.append(future)
 
         if self.is_available:
             self._process_next()
 
-        return task_exec_id
+        return future
 
     def _process_next(self):
         if not self._task_queue:
             return
 
-        self._current_task_exec_id = self._task_queue.popleft()
-        task_kwargs = self._task_exec_ids.pop(self._current_task_exec_id)
+        self._current_task_future = self._task_queue.popleft()
+        task_kwargs = self._current_task_future.task_kwargs
 
-        self._task_executor.create_task(**task_kwargs)
+        # Set up a callback to mark the future as done when task completes
+        def on_task_done(result):
+            if not self._current_task_future.done():
+                self._current_task_future.set_result(result)
+
+        self._task_executor.create_task(**task_kwargs, _callbacks=[on_task_done])
         if self._task_executor.has_task:
             self.sigComputationStarted.emit()
             self._task_executor.start()
@@ -92,7 +102,12 @@ class TaskExecutorQueue(QObject):
             return
 
         with block_signals(self._task_executor):
+            current_task_future = self._task_futures.get(
+                self._current_task_exec_id, None
+            )
             self._task_executor.cancel_running_task()
+            if current_task_future is not None and not current_task_future.done():
+                current_task_future.cancel()
             # stop and remove the current task from the stack
             self._task_executor.stop(wait=wait)
             # signal that processing is done
@@ -110,17 +125,31 @@ class TaskExecutorQueue(QObject):
         else:
             self._cancel_pending_task(task_exec_id)
 
+    def _cancel_future(self, future) -> bool:
+        current_task_future = self._task_futures.get(self._current_task_exec_id, None)
+        task_exec_id = future.task_exec_id
+
+        # If task is currently running
+        if future == current_task_future:
+            self.cancel_running_task()
+            return True
+        elif task_exec_id in self._task_futures:
+            self._cancel_pending_task(task_exec_id=task_exec_id)
+            return True
+        return False
+
     def _cancel_pending_task(self, task_exec_id: TaskExecutionID):
         # If task is not currently running, remove from queue
-        if task_exec_id in self._task_exec_ids:
+        if task_exec_id in self._task_futures:
             # Remove from queue
             if task_exec_id in self._task_queue:
                 self._task_queue.remove(task_exec_id)
-                del self._task_exec_ids[task_exec_id]
+                future = self._task_futures.pop(task_exec_id)
+                future.set_running_or_notify_cancel()
 
     def cancel_all_tasks(self, wait=True):
         """Cancel all pending and running tasks in the queue."""
-        tasks_exec_ids = self._task_exec_ids.keys()
+        tasks_exec_ids = self._task_futures.keys()
         for tasks_exec_id in tasks_exec_ids:
             self.cancel_task(task_exec_id=tasks_exec_id)
 
@@ -130,7 +159,7 @@ class TaskExecutorQueue(QObject):
         """
         self._task_executor.finished.disconnect(self._process_ended)
         self._task_queue.clear()
-        self._task_exec_ids.clear()
+        self._task_futures.clear()
         self._current_task_exec_id = None
         self._task_executor.stop(wait=True)
         self._task_executor = None

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -95,7 +95,6 @@ class TaskExecutorQueue(QObject):
             self._task_executor.cancel_running_task()
             # stop and remove the current task from the stack
             self._task_executor.stop(wait=wait)
-            self._current_task_id = None
             # signal that processing is done
             self._process_ended_direct(task_executor=self._task_executor)
 
@@ -108,7 +107,6 @@ class TaskExecutorQueue(QObject):
         # If task is currently running, use existing cancel method
         if self._current_task_id == task_id:
             self.cancel_running_task()
-            return True
         else:
             self._cancel_pending_task(task_id)
 

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import uuid
-
-from concurrent.futures import Future
 from collections import deque
+from concurrent.futures import Future
 from typing import Deque
 from typing import Dict
 from typing import Iterable
@@ -14,9 +13,10 @@ from AnyQt.QtCore import pyqtSignal as Signal
 from ..qt_utils.signals import block_signals
 from .base import TaskExecutionID
 from .threaded import ThreadedTaskExecutor
+from ._future import ExecutorFutureHandler, TaskFuture
 
 
-class TaskExecutorQueue(QObject):
+class TaskExecutorQueue(QObject, ExecutorFutureHandler):
     """
     Processing Queue with a First In, First Out behavior.
 
@@ -35,7 +35,7 @@ class TaskExecutorQueue(QObject):
         """Queue storing task IDs in FIFO order"""
         self._task_futures: Dict[str:Future] = {}
         """Dictionary mapping task IDs to their keyword arguments"""
-        self._current_task_exec_id: TaskExecutionID | None = None
+        self._current_task_future: TaskFuture | None = None
         self._task_executor: ThreadedTaskExecutor = _ThreadedTaskExecutor(
             ewokstaskclass=ewokstaskclass
         )
@@ -43,7 +43,7 @@ class TaskExecutorQueue(QObject):
 
     @property
     def is_available(self) -> bool:
-        return self._current_task_exec_id is None
+        return self._current_task_future is None
 
     def add(self, **kwargs) -> Future:
         """Add a task `ewokstaskclass` execution request
@@ -51,7 +51,7 @@ class TaskExecutorQueue(QObject):
         :return: Task identifier (UUID) that can be used to cancel the task
         """
         task_exec_id = str(uuid.uuid4())
-        future = Future(task_exec_id=task_exec_id, executor=self)
+        future = TaskFuture(task_exec_id=task_exec_id, executor=self)
 
         future.task_kwargs = kwargs
 
@@ -69,13 +69,9 @@ class TaskExecutorQueue(QObject):
 
         self._current_task_future = self._task_queue.popleft()
         task_kwargs = self._current_task_future.task_kwargs
+        self._current_task_future.set_running_or_notify_cancel()
 
-        # Set up a callback to mark the future as done when task completes
-        def on_task_done(result):
-            if not self._current_task_future.done():
-                self._current_task_future.set_result(result)
-
-        self._task_executor.create_task(**task_kwargs, _callbacks=[on_task_done])
+        self._task_executor.create_task(**task_kwargs)
         if self._task_executor.has_task:
             self.sigComputationStarted.emit()
             self._task_executor.start()
@@ -86,14 +82,17 @@ class TaskExecutorQueue(QObject):
         self._process_ended_direct(self.sender())
 
     def _process_ended_direct(self, task_executor: "_ThreadedTaskExecutor"):
+        self._current_task_future.set_result(
+            self._task_executor.current_task.get_output_values()
+        )
         for callback in task_executor.callbacks:
             callback()
         self.sigComputationEnded.emit()
-        self._current_task_exec_id = None
+        self._current_task_future = None
         if self.is_available:
             self._process_next()
 
-    def cancel_running_task(self, wait=True):
+    def _cancel_running_task(self, wait=True):
         """
         will abort current task.
         task_executor signal 'finished' will be blocked but callbacks will be executed to ensure a safe processing
@@ -102,12 +101,7 @@ class TaskExecutorQueue(QObject):
             return
 
         with block_signals(self._task_executor):
-            current_task_future = self._task_futures.get(
-                self._current_task_exec_id, None
-            )
-            self._task_executor.cancel_running_task()
-            if current_task_future is not None and not current_task_future.done():
-                current_task_future.cancel()
+            self._task_executor._cancel_running_task()
             # stop and remove the current task from the stack
             self._task_executor.stop(wait=wait)
             # signal that processing is done
@@ -120,18 +114,17 @@ class TaskExecutorQueue(QObject):
         :return: True if the task was successfully cancelled, False otherwise
         """
         # If task is currently running, use existing cancel method
-        if self._current_task_exec_id == task_exec_id:
-            self.cancel_running_task()
+        if self._current_task_future.task_exec_id == task_exec_id:
+            self._cancel_running_task()
         else:
             self._cancel_pending_task(task_exec_id)
 
     def _cancel_future(self, future) -> bool:
-        current_task_future = self._task_futures.get(self._current_task_exec_id, None)
         task_exec_id = future.task_exec_id
 
         # If task is currently running
-        if future == current_task_future:
-            self.cancel_running_task()
+        if future.task_exec_id == self._current_task_future.task_exec_id:
+            self._cancel_running_task()
             return True
         elif task_exec_id in self._task_futures:
             self._cancel_pending_task(task_exec_id=task_exec_id)
@@ -160,7 +153,7 @@ class TaskExecutorQueue(QObject):
         self._task_executor.finished.disconnect(self._process_ended)
         self._task_queue.clear()
         self._task_futures.clear()
-        self._current_task_exec_id = None
+        self._current_task_future = None
         self._task_executor.stop(wait=True)
         self._task_executor = None
 

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import concurrent.futures
 import uuid
+import warnings
 from collections import deque
 from concurrent.futures import Future
 from typing import Deque
@@ -11,9 +13,10 @@ from AnyQt.QtCore import QObject
 from AnyQt.QtCore import pyqtSignal as Signal
 
 from ..qt_utils.signals import block_signals
+from ._future import ExecutorFutureHandler
+from ._future import TaskFuture
 from .base import TaskExecutionID
 from .threaded import ThreadedTaskExecutor
-from ._future import ExecutorFutureHandler, TaskFuture
 
 
 class TaskExecutorQueue(QObject, ExecutorFutureHandler):
@@ -45,7 +48,7 @@ class TaskExecutorQueue(QObject, ExecutorFutureHandler):
     def is_available(self) -> bool:
         return self._current_task_future is None
 
-    def add(self, **kwargs) -> Future:
+    def add(self, **kwargs) -> TaskFuture:
         """Add a task `ewokstaskclass` execution request
 
         :return: Task identifier (UUID) that can be used to cancel the task
@@ -82,9 +85,13 @@ class TaskExecutorQueue(QObject, ExecutorFutureHandler):
         self._process_ended_direct(self.sender())
 
     def _process_ended_direct(self, task_executor: "_ThreadedTaskExecutor"):
-        self._current_task_future.set_result(
-            self._task_executor.current_task.get_output_values()
-        )
+        if self._task_executor.current_task and (
+            not self._task_executor.current_task.cancelled
+        ):
+            self._current_task_future.set_result(
+                self._task_executor.current_task.get_output_values()
+            )
+
         for callback in task_executor.callbacks:
             callback()
         self.sigComputationEnded.emit()
@@ -93,12 +100,17 @@ class TaskExecutorQueue(QObject, ExecutorFutureHandler):
             self._process_next()
 
     def cancel_running_task(self, wait=True):
+        warnings.warn(
+            f"'cancel_running_task' has been deprecated. Processing cancellation can now be done by the Future created during the task submission",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # To check: at the moment the closest would be something like:
         current_future = self._current_task_future
         if not current_future:
             return
         if wait:
-            current_future.result()
+            concurrent.futures.wait(current_future)
         else:
             current_future.cancel()
 
@@ -117,44 +129,23 @@ class TaskExecutorQueue(QObject, ExecutorFutureHandler):
             # signal that processing is done
             self._process_ended_direct(task_executor=self._task_executor)
 
-    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
-        """Cancel a task by its identifier
-
-        :param task_exec_id: The identifier returned by add()
-        :return: True if the task was successfully cancelled, False otherwise
-        """
-        # If task is currently running, use existing cancel method
-        if self._current_task_future.task_exec_id == task_exec_id:
-            self._cancel_running_task()
-        else:
-            self._cancel_pending_task(task_exec_id)
-
     def _cancel_future(self, future) -> bool:
         task_exec_id = future.task_exec_id
-
-        # If task is currently running
-        if future.task_exec_id == self._current_task_future.task_exec_id:
-            self._cancel_running_task()
-            return True
-        elif task_exec_id in self._task_futures:
+        if task_exec_id in self._task_futures.keys():
             self._cancel_pending_task(task_exec_id=task_exec_id)
             return True
         return False
 
-    def _cancel_pending_task(self, task_exec_id: TaskExecutionID):
-        # If task is not currently running, remove from queue
-        if task_exec_id in self._task_futures:
-            # Remove from queue
-            if task_exec_id in self._task_queue:
-                self._task_queue.remove(task_exec_id)
-                future = self._task_futures.pop(task_exec_id)
-                future.set_running_or_notify_cancel()
+    def _abort_future(self, future) -> bool:
+        if future.task_exec_id == self._current_task_future.task_exec_id:
+            self._cancel_running_task()
+            return True
+        return False
 
-    def cancel_all_tasks(self, wait=True):
-        """Cancel all pending and running tasks in the queue."""
-        tasks_exec_ids = self._task_futures.keys()
-        for tasks_exec_id in tasks_exec_ids:
-            self.cancel_task(task_exec_id=tasks_exec_id)
+    def _cancel_pending_task(self, task_exec_id: TaskExecutionID):
+        future = self._task_futures.pop(task_exec_id, None)
+        if future in self._task_queue:
+            self._task_queue.remove(future)
 
     def stop(self):
         """

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -94,11 +94,13 @@ class TaskExecutorQueue(QObject, ExecutorFutureHandler):
 
     def cancel_running_task(self, wait=True):
         # To check: at the moment the closest would be something like:
+        current_future = self._current_task_future
+        if not current_future:
+            return
         if wait:
-            self._current_task_future.result()
+            current_future.result()
         else:
-            self._current_task_future.cancel()
-        self._current_task_future.wai
+            current_future.cancel()
 
     def _cancel_running_task(self, wait=True):
         """

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -39,11 +39,10 @@ class TaskExecutorQueue(QObject):
             ewokstaskclass=ewokstaskclass
         )
         self._task_executor.finished.connect(self._process_ended)
-        self._available: bool = True
 
     @property
     def is_available(self) -> bool:
-        return self._available
+        return self._current_task_exec_id is None
 
     def add(self, **kwargs) -> TaskExecutionID:
         """Add a task `ewokstaskclass` execution request
@@ -63,7 +62,6 @@ class TaskExecutorQueue(QObject):
         if not self._task_queue:
             return
 
-        self._available = False
         self._current_task_exec_id = self._task_queue.popleft()
         task_kwargs = self._task_exec_ids.pop(self._current_task_exec_id)
 
@@ -81,7 +79,6 @@ class TaskExecutorQueue(QObject):
         for callback in task_executor.callbacks:
             callback()
         self.sigComputationEnded.emit()
-        self._available = True
         self._current_task_exec_id = None
         if self.is_available:
             self._process_next()

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -1,4 +1,10 @@
-from queue import Queue
+from __future__ import annotations
+
+import uuid
+from collections import deque
+from typing import Any
+from typing import Deque
+from typing import Dict
 from typing import Iterable
 
 from AnyQt.QtCore import QObject
@@ -8,8 +14,13 @@ from ..qt_utils.signals import block_signals
 from .threaded import ThreadedTaskExecutor
 
 
-class TaskExecutorQueue(QObject, Queue):
-    """Processing Queue with a First In, First Out behavior"""
+class TaskExecutorQueue(QObject):
+    """
+    Processing Queue with a First In, First Out behavior.
+
+    When a task is added, it is put in a queue and executed when the current task is finished.
+    `add()` method returns a task identifier that can be used to cancel the task before it starts.
+    """
 
     sigComputationStarted = Signal()
     """Signal emitted when a computation is started"""
@@ -18,28 +29,44 @@ class TaskExecutorQueue(QObject, Queue):
 
     def __init__(self, ewokstaskclass):
         super().__init__()
-        self._task_executor = _ThreadedTaskExecutor(ewokstaskclass=ewokstaskclass)
+        self._task_queue: Deque[str] = deque()
+        """Queue storing task IDs in FIFO order"""
+        self._task_ids: Dict[str, Dict[str, Any]] = {}
+        """Dictionary mapping task IDs to their keyword arguments"""
+        self._current_task_id: str | None = None
+        self._task_executor: ThreadedTaskExecutor = _ThreadedTaskExecutor(
+            ewokstaskclass=ewokstaskclass
+        )
         self._task_executor.finished.connect(self._process_ended)
-        self._available = True
-        """Simple thread to know if we can do some processing
-        and avoid to mix thinks with QSignals and different threads
-        """
+        self._available: bool = True
 
     @property
     def is_available(self) -> bool:
         return self._available
 
-    def add(self, **kwargs):
-        """Add a task `ewokstaskclass` execution request"""
-        super().put(kwargs)
+    def add(self, **kwargs) -> str:
+        """Add a task `ewokstaskclass` execution request
+
+        :return: Task identifier (UUID) that can be used to cancel the task
+        """
+        task_id = str(uuid.uuid4())
+        self._task_ids[task_id] = kwargs
+        self._task_queue.append(task_id)
+
         if self.is_available:
             self._process_next()
 
+        return task_id
+
     def _process_next(self):
-        if Queue.empty(self):
+        if not self._task_queue:
             return
+
         self._available = False
-        self._task_executor.create_task(**Queue.get(self))
+        self._current_task_id = self._task_queue.popleft()
+        task_kwargs = self._task_ids.pop(self._current_task_id)
+
+        self._task_executor.create_task(**task_kwargs)
         if self._task_executor.has_task:
             self.sigComputationStarted.emit()
             self._task_executor.start()
@@ -54,6 +81,7 @@ class TaskExecutorQueue(QObject, Queue):
             callback()
         self.sigComputationEnded.emit()
         self._available = True
+        self._current_task_id = None
         if self.is_available:
             self._process_next()
 
@@ -62,27 +90,59 @@ class TaskExecutorQueue(QObject, Queue):
         will cancel current task.
         task_executor signal 'finished' will be blocked but callbacks will be executed to ensure a safe processing
         """
-        if not self.is_available:
-            with block_signals(self._task_executor):
-                self._task_executor.cancel_running_task()
-                # stop and remove the current task from the stack
-                self._task_executor.stop(wait=wait)
-                # signal that processing is done
-                self._process_ended_direct(task_executor=self._task_executor)
+        with block_signals(self._task_executor):
+            self._task_executor.cancel_running_task()
+            # stop and remove the current task from the stack
+            self._task_executor.stop(wait=wait)
+            self._current_task_id = None
+            # signal that processing is done
+            self._process_ended_direct(task_executor=self._task_executor)
+
+    def cancel_task(self, task_id: str) -> bool:
+        """Cancel a task by its identifier
+
+        :param task_id: The identifier returned by add()
+        :return: True if the task was successfully cancelled, False otherwise
+        """
+        # If task is currently running, use existing cancel method
+        if self._current_task_id == task_id:
+            self.cancel_running_task()
+            return True
+        # If task is not currently running, remove from queue
+        elif task_id in self._task_ids:
+            # Remove from queue
+            if task_id in self._task_queue:
+                self._task_queue.remove(task_id)
+                del self._task_ids[task_id]
+                return True
+
+        return False
+
+    def cancel_all_tasks(self, wait=True):
+        """Cancel all pending and running tasks in the queue."""
+        # first clear the queue of pending tasks
+        self._task_queue.clear()
+        self._task_ids.clear()
+        # then cancel the currently running task, if any
+        self.cancel_running_task(wait=wait)
 
     def stop(self):
         """
         stop the queue. Wait for the last processing to be finished and reset current_task
         """
         self._task_executor.finished.disconnect(self._process_ended)
-        while not self.empty():
-            self.get()
+        self._task_queue.clear()
+        self._task_ids.clear()
+        self._current_task_id = None
         self._task_executor.stop(wait=True)
         self._task_executor = None
 
     @property
     def current_task(self):
         return self._task_executor.current_task
+
+    def __len__(self):
+        return len(self._task_queue) + (1 if self._current_task_id else 0)
 
 
 class _ThreadedTaskExecutor(ThreadedTaskExecutor):

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -91,6 +91,9 @@ class TaskExecutorQueue(QObject):
         will abort current task.
         task_executor signal 'finished' will be blocked but callbacks will be executed to ensure a safe processing
         """
+        if self.is_available:
+            return
+
         with block_signals(self._task_executor):
             self._task_executor.cancel_running_task()
             # stop and remove the current task from the stack

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -120,11 +120,9 @@ class TaskExecutorQueue(QObject):
 
     def cancel_all_tasks(self, wait=True):
         """Cancel all pending and running tasks in the queue."""
-        # first clear the queue of pending tasks
-        self._task_queue.clear()
-        self._task_exec_ids.clear()
-        # then cancel the currently running task, if any
-        self.cancel_running_task(wait=wait)
+        tasks_exec_ids = self._task_exec_ids.keys()
+        for tasks_exec_id in tasks_exec_ids:
+            self.cancel_task(task_exec_id=tasks_exec_id)
 
     def stop(self):
         """

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -30,11 +30,11 @@ class TaskExecutorQueue(QObject):
 
     def __init__(self, ewokstaskclass):
         super().__init__()
-        self._task_queue: Deque[str] = deque()
+        self._task_queue: Deque[TaskExecutionID] = deque()
         """Queue storing task IDs in FIFO order"""
-        self._task_ids: Dict[str, Dict[str, Any]] = {}
+        self._task_ids: Dict[TaskExecutionID, Dict[str, Any]] = {}
         """Dictionary mapping task IDs to their keyword arguments"""
-        self._current_task_id: str | None = None
+        self._current_task_id: TaskExecutionID | None = None
         self._task_executor: ThreadedTaskExecutor = _ThreadedTaskExecutor(
             ewokstaskclass=ewokstaskclass
         )
@@ -45,7 +45,7 @@ class TaskExecutorQueue(QObject):
     def is_available(self) -> bool:
         return self._available
 
-    def add(self, **kwargs) -> str:
+    def add(self, **kwargs) -> TaskExecutionID:
         """Add a task `ewokstaskclass` execution request
 
         :return: Task identifier (UUID) that can be used to cancel the task
@@ -99,7 +99,7 @@ class TaskExecutorQueue(QObject):
             # signal that processing is done
             self._process_ended_direct(task_executor=self._task_executor)
 
-    def cancel_task(self, task_id: str):
+    def cancel_task(self, task_id: TaskExecutionID):
         """Cancel a task by its identifier
 
         :param task_id: The identifier returned by add()

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -92,6 +92,14 @@ class TaskExecutorQueue(QObject, ExecutorFutureHandler):
         if self.is_available:
             self._process_next()
 
+    def cancel_running_task(self, wait=True):
+        # To check: at the moment the closest would be something like:
+        if wait:
+            self._current_task_future.result()
+        else:
+            self._current_task_future.cancel()
+        self._current_task_future.wai
+
     def _cancel_running_task(self, wait=True):
         """
         will abort current task.

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -11,8 +11,8 @@ from AnyQt.QtCore import QObject
 from AnyQt.QtCore import pyqtSignal as Signal
 
 from ..qt_utils.signals import block_signals
-from .threaded import ThreadedTaskExecutor
 from .base import TaskExecutionID
+from .threaded import ThreadedTaskExecutor
 
 
 class TaskExecutorQueue(QObject):

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -98,7 +98,7 @@ class TaskExecutorQueue(QObject):
             # signal that processing is done
             self._process_ended_direct(task_executor=self._task_executor)
 
-    def cancel_task(self, task_exec_id: TaskExecutionID):
+    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         """Cancel a task by its identifier
 
         :param task_exec_id: The identifier returned by add()

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -12,6 +12,7 @@ from AnyQt.QtCore import pyqtSignal as Signal
 
 from ..qt_utils.signals import block_signals
 from .threaded import ThreadedTaskExecutor
+from .base import TaskExecutionID
 
 
 class TaskExecutorQueue(QObject):
@@ -87,7 +88,7 @@ class TaskExecutorQueue(QObject):
 
     def cancel_running_task(self, wait=True):
         """
-        will cancel current task.
+        will abort current task.
         task_executor signal 'finished' will be blocked but callbacks will be executed to ensure a safe processing
         """
         with block_signals(self._task_executor):
@@ -98,7 +99,7 @@ class TaskExecutorQueue(QObject):
             # signal that processing is done
             self._process_ended_direct(task_executor=self._task_executor)
 
-    def cancel_task(self, task_id: str) -> bool:
+    def cancel_task(self, task_id: str):
         """Cancel a task by its identifier
 
         :param task_id: The identifier returned by add()
@@ -108,15 +109,16 @@ class TaskExecutorQueue(QObject):
         if self._current_task_id == task_id:
             self.cancel_running_task()
             return True
+        else:
+            self._cancel_pending_task(task_id)
+
+    def _cancel_pending_task(self, task_id: TaskExecutionID):
         # If task is not currently running, remove from queue
-        elif task_id in self._task_ids:
+        if task_id in self._task_ids:
             # Remove from queue
             if task_id in self._task_queue:
                 self._task_queue.remove(task_id)
                 del self._task_ids[task_id]
-                return True
-
-        return False
 
     def cancel_all_tasks(self, wait=True):
         """Cancel all pending and running tasks in the queue."""

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -32,9 +32,9 @@ class TaskExecutorQueue(QObject):
         super().__init__()
         self._task_queue: Deque[TaskExecutionID] = deque()
         """Queue storing task IDs in FIFO order"""
-        self._task_ids: Dict[TaskExecutionID, Dict[str, Any]] = {}
+        self._task_exec_ids: Dict[TaskExecutionID, Dict[str, Any]] = {}
         """Dictionary mapping task IDs to their keyword arguments"""
-        self._current_task_id: TaskExecutionID | None = None
+        self._current_task_exec_id: TaskExecutionID | None = None
         self._task_executor: ThreadedTaskExecutor = _ThreadedTaskExecutor(
             ewokstaskclass=ewokstaskclass
         )
@@ -50,22 +50,22 @@ class TaskExecutorQueue(QObject):
 
         :return: Task identifier (UUID) that can be used to cancel the task
         """
-        task_id = str(uuid.uuid4())
-        self._task_ids[task_id] = kwargs
-        self._task_queue.append(task_id)
+        task_exec_id = str(uuid.uuid4())
+        self._task_exec_ids[task_exec_id] = kwargs
+        self._task_queue.append(task_exec_id)
 
         if self.is_available:
             self._process_next()
 
-        return task_id
+        return task_exec_id
 
     def _process_next(self):
         if not self._task_queue:
             return
 
         self._available = False
-        self._current_task_id = self._task_queue.popleft()
-        task_kwargs = self._task_ids.pop(self._current_task_id)
+        self._current_task_exec_id = self._task_queue.popleft()
+        task_kwargs = self._task_exec_ids.pop(self._current_task_exec_id)
 
         self._task_executor.create_task(**task_kwargs)
         if self._task_executor.has_task:
@@ -82,7 +82,7 @@ class TaskExecutorQueue(QObject):
             callback()
         self.sigComputationEnded.emit()
         self._available = True
-        self._current_task_id = None
+        self._current_task_exec_id = None
         if self.is_available:
             self._process_next()
 
@@ -101,31 +101,31 @@ class TaskExecutorQueue(QObject):
             # signal that processing is done
             self._process_ended_direct(task_executor=self._task_executor)
 
-    def cancel_task(self, task_id: TaskExecutionID):
+    def cancel_task(self, task_exec_id: TaskExecutionID):
         """Cancel a task by its identifier
 
-        :param task_id: The identifier returned by add()
+        :param task_exec_id: The identifier returned by add()
         :return: True if the task was successfully cancelled, False otherwise
         """
         # If task is currently running, use existing cancel method
-        if self._current_task_id == task_id:
+        if self._current_task_exec_id == task_exec_id:
             self.cancel_running_task()
         else:
-            self._cancel_pending_task(task_id)
+            self._cancel_pending_task(task_exec_id)
 
-    def _cancel_pending_task(self, task_id: TaskExecutionID):
+    def _cancel_pending_task(self, task_exec_id: TaskExecutionID):
         # If task is not currently running, remove from queue
-        if task_id in self._task_ids:
+        if task_exec_id in self._task_exec_ids:
             # Remove from queue
-            if task_id in self._task_queue:
-                self._task_queue.remove(task_id)
-                del self._task_ids[task_id]
+            if task_exec_id in self._task_queue:
+                self._task_queue.remove(task_exec_id)
+                del self._task_exec_ids[task_exec_id]
 
     def cancel_all_tasks(self, wait=True):
         """Cancel all pending and running tasks in the queue."""
         # first clear the queue of pending tasks
         self._task_queue.clear()
-        self._task_ids.clear()
+        self._task_exec_ids.clear()
         # then cancel the currently running task, if any
         self.cancel_running_task(wait=wait)
 
@@ -135,8 +135,8 @@ class TaskExecutorQueue(QObject):
         """
         self._task_executor.finished.disconnect(self._process_ended)
         self._task_queue.clear()
-        self._task_ids.clear()
-        self._current_task_id = None
+        self._task_exec_ids.clear()
+        self._current_task_exec_id = None
         self._task_executor.stop(wait=True)
         self._task_executor = None
 
@@ -145,7 +145,7 @@ class TaskExecutorQueue(QObject):
         return self._task_executor.current_task
 
     def __len__(self):
-        return len(self._task_queue) + (1 if self._current_task_id else 0)
+        return len(self._task_queue) + (1 if self._current_task_exec_id else 0)
 
 
 class _ThreadedTaskExecutor(ThreadedTaskExecutor):

--- a/src/ewoksorange/gui/concurrency/queued.py
+++ b/src/ewoksorange/gui/concurrency/queued.py
@@ -13,13 +13,14 @@ from AnyQt.QtCore import QObject
 from AnyQt.QtCore import pyqtSignal as Signal
 
 from ..qt_utils.signals import block_signals
-from ._future import ExecutorFutureHandler
+from ._Executor import CancellableExecutor, AbortableExecutor
+
 from ._future import TaskFuture
 from .base import TaskExecutionID
 from .threaded import ThreadedTaskExecutor
 
 
-class TaskExecutorQueue(QObject, ExecutorFutureHandler):
+class TaskExecutorQueue(QObject, CancellableExecutor, AbortableExecutor):
     """
     Processing Queue with a First In, First Out behavior.
 

--- a/src/ewoksorange/gui/concurrency/threaded.py
+++ b/src/ewoksorange/gui/concurrency/threaded.py
@@ -2,30 +2,35 @@ from typing import Optional
 
 from AnyQt.QtCore import QThread
 
+from ..concurrency._future import TaskFuture
+from ..qt_utils.signals import block_signals
 from .base import TaskExecutor
 
 
 class ThreadedTaskExecutor(QThread, TaskExecutor):
     """Create and execute an Ewoks task in a dedicated thread."""
 
-    def run(self) -> None:
-        self.execute_task()
-
     def stop(self, timeout: Optional[float] = None, wait: bool = False) -> None:
         """Stop the current thread"""
-        self.blockSignals(True)
-        if wait:
-            if timeout:
-                self.wait(timeout * 1000)
-            else:
-                self.wait()
-        if self.isRunning():
-            self.quit()
+        with block_signals(self):
+            if wait:
+                if timeout:
+                    self.wait(timeout * 1000)
+                else:
+                    self.wait()
+            if self.isRunning():
+                self.quit()
 
-    def _cancel_running_task(self):
-        """
-        cancel current processing.
-        The targetted EwoksTask must have implemented the 'cancel' function
-        """
-        if self.current_task is not None:
+    def _cancel_future(self, future: TaskFuture) -> bool:
+        raise NotImplementedError("Cannot cancel a task")
+
+    def _abort_future(self, future: TaskFuture) -> bool:
+        # TODO: this class must store the future or the task_exec_id in order to be able to cancel it
+
+        if (
+            self.__current_future
+            and future.task_exec_id == self.__current_future.task_exec_id
+        ):
             self.current_task.cancel()
+            return True
+        return False

--- a/src/ewoksorange/gui/concurrency/threaded.py
+++ b/src/ewoksorange/gui/concurrency/threaded.py
@@ -22,7 +22,7 @@ class ThreadedTaskExecutor(QThread, TaskExecutor):
         if self.isRunning():
             self.quit()
 
-    def cancel_running_task(self):
+    def _cancel_running_task(self):
         """
         cancel current processing.
         The targetted EwoksTask must have implemented the 'cancel' function

--- a/src/ewoksorange/gui/concurrency/threaded.py
+++ b/src/ewoksorange/gui/concurrency/threaded.py
@@ -1,10 +1,22 @@
+import concurrent.futures
+import uuid
+import logging
+from dataclasses import dataclass
+from typing import Callable
+from typing import Dict
+from typing import Iterable
 from typing import Optional
 
+from AnyQt.QtCore import QObject
 from AnyQt.QtCore import QThread
+from AnyQt.QtCore import pyqtSignal as Signal
 
+from ..concurrency._Executor import AbortableExecutor, CancellableExecutor
 from ..concurrency._future import TaskFuture
 from ..qt_utils.signals import block_signals
 from .base import TaskExecutor
+
+_logger = logging.getLogger(__name__)
 
 
 class ThreadedTaskExecutor(QThread, TaskExecutor):
@@ -13,6 +25,17 @@ class ThreadedTaskExecutor(QThread, TaskExecutor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__current_future = None
+
+    def create_task(self, log_missing_inputs=False, **kwargs):
+        future = self._build_future()
+
+        if self.isRunning():
+            err = "A processing is already ongoing"
+            future.set_exception(RuntimeError(err))
+            _logger.error(err)
+            return future
+        super().create_task(log_missing_inputs, **kwargs)
+        return future
 
     def _build_future(self):
         self.__current_future = super()._build_future()
@@ -41,3 +64,174 @@ class ThreadedTaskExecutor(QThread, TaskExecutor):
             self.current_task.cancel()
             return True
         return False
+
+
+@dataclass
+class _TaskExecutorState:
+    task_executor: ThreadedTaskExecutor
+    future: TaskFuture
+    callbacks: Iterable[Callable[[ThreadedTaskExecutor, TaskFuture], None]]
+    started: bool = False
+
+
+class MultiThreadedTaskExecutor(QObject, CancellableExecutor, AbortableExecutor):
+    """
+    Execute each submitted Ewoks task in its own thread.
+
+    Contrary to :class:`ThreadedTaskExecutor`, this executor owns the mapping
+    between futures and per-run threads. This makes abort/cleanup independent
+    from the widget using it.
+    """
+
+    sigComputationStarted = Signal()
+    """Signal emitted when a computation is started"""
+
+    sigComputationEnded = Signal()
+    """Signal emitted when a computation is ended"""
+
+    def __init__(self, ewokstaskclass):
+        super().__init__()
+        self.__ewokstaskclass = ewokstaskclass
+        self.__task_executors: Dict[int, _TaskExecutorState] = dict()
+        self.__last_output_variables = dict()
+        self.__last_task_succeeded = None
+        self.__last_task_done = None
+        self.__last_task_exception = None
+
+    def create_task(
+        self,
+        _callbacks: Iterable[
+            Callable[[ThreadedTaskExecutor, TaskFuture], None]
+        ] = tuple(),
+        log_missing_inputs: bool = False,
+        **kwargs,
+    ) -> None:
+        """Create the next task to be executed in a dedicated thread."""
+        future = TaskFuture(task_exec_id=str(uuid.uuid4()), executor=self)
+        future.task_kwargs = kwargs
+
+        task_executor = ThreadedTaskExecutor(ewokstaskclass=self.__ewokstaskclass)
+        task_executor.create_task(log_missing_inputs=log_missing_inputs, **kwargs)
+
+        self.__add_task_executor(task_executor, future, _callbacks)
+
+    def execute_task(self) -> TaskFuture:
+        """Execute the task created by :meth:`create_task`."""
+        state = self.__get_pending_state()
+        if state is None:
+            future = TaskFuture(task_exec_id=str(uuid.uuid4()), executor=self)
+            future.set_exception(RuntimeError("Task not defined."))
+            return future
+
+        task_executor = state.task_executor
+        future = state.future
+        state.started = True
+        task_executor.finished.connect(self.__process_ended)
+
+        if task_executor.has_task:
+            self.sigComputationStarted.emit()
+            task_executor.start()
+        else:
+            task_executor.finished.emit()
+        return future
+
+    def __process_ended(self):
+        self.__process_ended_direct(self.sender())
+
+    def __process_ended_direct(self, task_executor: ThreadedTaskExecutor):
+        state = self.__task_executors.get(id(task_executor))
+        if state is None:
+            return
+
+        future = state.future
+        self.__last_output_variables = task_executor.output_variables
+        self.__last_task_succeeded = task_executor.succeeded
+        self.__last_task_done = task_executor.done
+        self.__last_task_exception = task_executor.exception
+
+        if not future.done():
+            exception = task_executor.exception
+            if exception is not None:
+                future.set_exception(exception)
+            elif task_executor.current_task is None:
+                future.set_exception(RuntimeError("Task not defined."))
+            else:
+                future.set_result(task_executor.current_task.get_output_values())
+
+        try:
+            for callback in state.callbacks:
+                callback(task_executor, future)
+            self.sigComputationEnded.emit()
+        finally:
+            self.__remove_task_executor(task_executor)
+
+    def stop(self, timeout: Optional[float] = None, wait: bool = False) -> None:
+        """Stop all tracked task threads."""
+        for state in list(self.__task_executors.values()):
+            task_executor = state.task_executor
+            if task_executor.receivers(task_executor.finished) > 0:
+                task_executor.finished.disconnect(self.__process_ended)
+            task_executor.stop(timeout=timeout, wait=wait)
+        self.__task_executors.clear()
+
+    def __add_task_executor(
+        self,
+        task_executor: ThreadedTaskExecutor,
+        future: TaskFuture,
+        callbacks: Iterable[Callable[[ThreadedTaskExecutor, TaskFuture], None]],
+    ) -> None:
+        self.__task_executors[id(task_executor)] = _TaskExecutorState(
+            task_executor=task_executor,
+            future=future,
+            callbacks=tuple(callbacks),
+        )
+
+    def __remove_task_executor(self, task_executor: ThreadedTaskExecutor) -> None:
+        if task_executor is None:
+            return
+        if task_executor.receivers(task_executor.finished) > 0:
+            task_executor.finished.disconnect(self.__process_ended)
+        self.__task_executors.pop(id(task_executor), None)
+
+    def __get_task_executor(
+        self, future: TaskFuture
+    ) -> Optional[ThreadedTaskExecutor]:
+        for state in self.__task_executors.values():
+            if state.future is future:
+                return state.task_executor
+        return None
+
+    def __get_pending_state(self) -> Optional[_TaskExecutorState]:
+        for state in self.__task_executors.values():
+            if not state.started:
+                return state
+        return None
+
+    @property
+    def task_succeeded(self) -> Optional[bool]:
+        return self.__last_task_succeeded
+
+    @property
+    def task_done(self) -> Optional[bool]:
+        return self.__last_task_done
+
+    @property
+    def task_exception(self) -> Optional[Exception]:
+        return self.__last_task_exception
+
+    @property
+    def output_variables(self) -> dict:
+        return self.__last_output_variables
+
+    def _cancel_future(self, future: TaskFuture) -> bool:
+        return False
+
+    def _abort_future(self, future: TaskFuture) -> bool:
+        task_executor = self.__get_task_executor(future)
+        if task_executor is None or task_executor.current_task is None:
+            return False
+
+        task_executor.current_task.cancel()
+        if not future.done():
+            future.set_exception(concurrent.futures.CancelledError())
+        return True

--- a/src/ewoksorange/gui/concurrency/threaded.py
+++ b/src/ewoksorange/gui/concurrency/threaded.py
@@ -10,6 +10,14 @@ from .base import TaskExecutor
 class ThreadedTaskExecutor(QThread, TaskExecutor):
     """Create and execute an Ewoks task in a dedicated thread."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__current_future = None
+
+    def _build_future(self):
+        self.__current_future = super()._build_future()
+        return self.__current_future
+
     def stop(self, timeout: Optional[float] = None, wait: bool = False) -> None:
         """Stop the current thread"""
         with block_signals(self):
@@ -26,7 +34,6 @@ class ThreadedTaskExecutor(QThread, TaskExecutor):
 
     def _abort_future(self, future: TaskFuture) -> bool:
         # TODO: this class must store the future or the task_exec_id in order to be able to cancel it
-
         if (
             self.__current_future
             and future.task_exec_id == self.__current_future.task_exec_id

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -20,6 +20,7 @@ from ewokscore.variable import value_from_transfer
 
 from ...orange_version import ORANGE_VERSION
 from ..utils.invalid_data import is_invalid_data
+from ..concurrency.base import TaskExecutionID
 
 # OWBaseWidget: lowest level Orange widget base class
 # OWWidget: highest level Orangewidget base class.
@@ -606,7 +607,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         """
         pass
 
-    def execute_ewoks_task(self, log_missing_inputs: bool = True) -> None | str:
+    def execute_ewoks_task(self, log_missing_inputs: bool = True) -> TaskExecutionID:
         """
         Execute the Ewoks task and propagate downstream on completion.
 
@@ -618,7 +619,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             propagate=True, log_missing_inputs=log_missing_inputs
         )
 
-    def execute_ewoks_task_without_propagation(self) -> None | str:
+    def execute_ewoks_task_without_propagation(self) -> TaskExecutionID:
         """
         Execute the Ewoks task without propagating outputs downstream.
 
@@ -728,11 +729,14 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             if ncallbacks > 1:
                 self.__post_task_execute(callbacks[1:])
 
-    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> None:
+    def _execute_ewoks_task(
+        self, propagate: bool, log_missing_inputs: bool
+    ) -> TaskExecutionID:
         """
         Subclasses must implement how the task is created and executed.
 
         :param propagate: Whether to propagate outputs downstream after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
+        :return: Task execution identifier. Can be used to cancel / abort a task.
         """
         raise NotImplementedError("Base class")

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -19,6 +19,7 @@ from ewokscore import missing_data
 from ewokscore.variable import value_from_transfer
 
 from ...orange_version import ORANGE_VERSION
+from ..concurrency._future import TaskFuture
 from ..concurrency.base import TaskExecutionID
 from ..utils.invalid_data import is_invalid_data
 
@@ -607,23 +608,23 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         """
         pass
 
-    def execute_ewoks_task(self, log_missing_inputs: bool = True) -> TaskExecutionID:
+    def execute_ewoks_task(self, log_missing_inputs: bool = True) -> TaskFuture:
         """
         Execute the Ewoks task and propagate downstream on completion.
 
         :param log_missing_inputs: Whether missing inputs should be logged.
-        :return: Task identifier if execution was queued, None otherwise.
+        :return: Future of the task execution.
         """
         _logger.debug("%s: execute ewoks task (with propagation)", self)
         return self._execute_ewoks_task(
             propagate=True, log_missing_inputs=log_missing_inputs
         )
 
-    def execute_ewoks_task_without_propagation(self) -> TaskExecutionID:
+    def execute_ewoks_task_without_propagation(self) -> TaskFuture:
         """
         Execute the Ewoks task without propagating outputs downstream.
 
-        :return: Task identifier if execution was queued, None otherwise.
+        :return: Future of the task execution.
         """
         _logger.debug("%s: execute ewoks task (without propagation)", self)
         return self._execute_ewoks_task(propagate=False, log_missing_inputs=False)
@@ -731,12 +732,12 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> TaskExecutionID:
+    ) -> TaskFuture:
         """
         Subclasses must implement how the task is created and executed.
 
         :param propagate: Whether to propagate outputs downstream after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
-        :return: Task execution identifier. Can be used to cancel / abort a task.
+        :return: Future of the task execution.
         """
         raise NotImplementedError("Base class")

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -683,11 +683,6 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             execinfo = scheme_ewoks_events(scheme, self._ewoks_execinfo)
 
         if self._ewoks_task_options:
-            print(
-                "self._ewoks_task_options = ",
-                self._ewoks_task_options,
-                type(self._ewoks_task_options),
-            )
             task_arguments = dict(self._ewoks_task_options)
         else:
             task_arguments = dict()

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -606,21 +606,26 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         """
         pass
 
-    def execute_ewoks_task(self, log_missing_inputs: bool = True) -> None:
+    def execute_ewoks_task(self, log_missing_inputs: bool = True) -> None | str:
         """
         Execute the Ewoks task and propagate downstream on completion.
 
         :param log_missing_inputs: Whether missing inputs should be logged.
+        :return: Task identifier if execution was queued, None otherwise.
         """
         _logger.debug("%s: execute ewoks task (with propagation)", self)
-        self._execute_ewoks_task(propagate=True, log_missing_inputs=log_missing_inputs)
+        return self._execute_ewoks_task(
+            propagate=True, log_missing_inputs=log_missing_inputs
+        )
 
-    def execute_ewoks_task_without_propagation(self) -> None:
+    def execute_ewoks_task_without_propagation(self) -> None | str:
         """
         Execute the Ewoks task without propagating outputs downstream.
+
+        :return: Task identifier if execution was queued, None otherwise.
         """
         _logger.debug("%s: execute ewoks task (without propagation)", self)
-        self._execute_ewoks_task(propagate=False, log_missing_inputs=False)
+        return self._execute_ewoks_task(propagate=False, log_missing_inputs=False)
 
     @property
     def task_succeeded(self) -> Optional[bool]:

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -19,8 +19,8 @@ from ewokscore import missing_data
 from ewokscore.variable import value_from_transfer
 
 from ...orange_version import ORANGE_VERSION
-from ..utils.invalid_data import is_invalid_data
 from ..concurrency.base import TaskExecutionID
+from ..utils.invalid_data import is_invalid_data
 
 # OWBaseWidget: lowest level Orange widget base class
 # OWWidget: highest level Orangewidget base class.

--- a/src/ewoksorange/gui/owwidgets/nothread.py
+++ b/src/ewoksorange/gui/owwidgets/nothread.py
@@ -45,8 +45,6 @@ class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
         except Exception as e:
             _logger.error(f"task failed: {e}", exc_info=True)
             future.set_exception(e)
-        else:
-            future.set_result(self.__task_executor.current_task.output_values)
 
         try:
             self.__post_task_exception = None

--- a/src/ewoksorange/gui/owwidgets/nothread.py
+++ b/src/ewoksorange/gui/owwidgets/nothread.py
@@ -2,11 +2,12 @@
 Synchronous (no-thread) Ewoks widget implementation.
 """
 
-import uuid
 import logging
+import uuid
 from typing import Optional
 
-from ..concurrency.base import TaskExecutor, TaskExecutionID
+from ..concurrency.base import TaskExecutionID
+from ..concurrency.base import TaskExecutor
 from .base import OWEwoksBaseWidget
 from .meta import ow_build_opts
 

--- a/src/ewoksorange/gui/owwidgets/nothread.py
+++ b/src/ewoksorange/gui/owwidgets/nothread.py
@@ -2,10 +2,11 @@
 Synchronous (no-thread) Ewoks widget implementation.
 """
 
+import uuid
 import logging
 from typing import Optional
 
-from ..concurrency.base import TaskExecutor
+from ..concurrency.base import TaskExecutor, TaskExecutionID
 from .base import OWEwoksBaseWidget
 from .meta import ow_build_opts
 
@@ -26,7 +27,9 @@ class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
         super().__init__(*args, **kwargs)
         self.__task_executor = TaskExecutor(self.ewokstaskclass)
 
-    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> None:
+    def _execute_ewoks_task(
+        self, propagate: bool, log_missing_inputs: bool
+    ) -> TaskExecutionID:
         """
         Create and execute the Task synchronously.
 
@@ -46,6 +49,9 @@ class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
                 self.propagate_downstream()
         finally:
             self._output_changed()
+        return str(
+            uuid.uuid4()
+        )  # Return a dummy TaskExecutionID since we're synchronous
 
     @property
     def task_succeeded(self) -> Optional[bool]:

--- a/src/ewoksorange/gui/owwidgets/nothread.py
+++ b/src/ewoksorange/gui/owwidgets/nothread.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from typing import Optional
 
-from ..concurrency.base import TaskExecutionID
+from ..concurrency._future import TaskFuture
 from ..concurrency.base import TaskExecutor
 from .base import OWEwoksBaseWidget
 from .meta import ow_build_opts
@@ -30,7 +30,7 @@ class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> TaskExecutionID:
+    ) -> TaskFuture:
         """
         Create and execute the Task synchronously.
 
@@ -41,18 +41,22 @@ class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
         try:
-            self.__task_executor.execute_task()
+            future: TaskFuture = self.__task_executor.execute_task()
         except Exception as e:
             _logger.error(f"task failed: {e}", exc_info=True)
+            future.set_exception(e)
+        else:
+            future.set_result(self.__task_executor.current_task.output_values)
+
         try:
             self.__post_task_exception = None
             if propagate:
                 self.propagate_downstream()
         finally:
             self._output_changed()
-        return str(
-            uuid.uuid4()
-        )  # Return a dummy TaskExecutionID since we're synchronous
+        # debattable implementation has the future could be returned before. Anyway this is simpler this way
+        # and processing design (processing in the main Qt thread) will block any other processing.
+        return future
 
     @property
     def task_succeeded(self) -> Optional[bool]:

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -125,7 +125,7 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> tuple[bool, TaskExecutionID]:
+    ) -> TaskExecutionID:
         """
         Prepare and start the background thread if idle.
 
@@ -135,7 +135,7 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """
         if self.__task_executor.isRunning():
             _logger.error("A processing is already ongoing")
-            return False, ""
+            return ""
         self.__task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
@@ -144,12 +144,12 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
                 self.__propagate = propagate
                 self.__task_executor.start()
                 self._current_task_exec_id = str(uuid.uuid4())
-                return True, self._current_task_exec_id
+                return self._current_task_exec_id
         else:
             self.__propagate = propagate
             self.__task_executor.finished.emit()
             self._current_task_exec_id = ""
-            return False, self._current_task_exec_id
+            return self._current_task_exec_id
 
     @property
     def task_executor(self):
@@ -221,7 +221,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> tuple[bool, TaskExecutionID]:
+    ) -> TaskExecutionID:
         """
         Create a fresh ThreadedTaskExecutor, register it, and start it if it has work.
 
@@ -239,7 +239,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
                     task_id = task_executor.start()
             else:
                 task_executor.finished.emit()
-        return True, task_id
+        return task_id
 
     @contextmanager
     def __init_task_executor(self, task_executor, propagate: bool):
@@ -337,6 +337,9 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         raise NotImplementedError
 
     def cancel_task(self, task_id):
+        self._cancel_running_task(task_id)
+
+    def _cancel_running_task(self, task_id):
         executor = self._get_task_executor(task_id)
         if executor is not None:
             executor.cancel_running_task()
@@ -369,7 +372,7 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> tuple[bool, TaskExecutionID]:
+    ) -> TaskExecutionID:
         """
         Queue the task for later execution in FIFO order.
 
@@ -431,11 +434,7 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executor_queue.cancel_running_task()
 
     def cancel_all_tasks(self):
-        """Cancel all pending and running tasks in the queue."""
-        # first clear the queue of pending tasks
-        while not self.__task_executor_queue.empty():
-            self.__task_executor_queue.get()
-        # then cancel the currently running task, if any
+        """Cancel (or abort) all pending and running tasks in the queue."""
         self.__task_executor_queue.cancel_all_tasks()
 
     def cancel_task(self, task_id):
@@ -445,4 +444,4 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         :param task_id: The ID of the task to cancel.
         :return: True if the task was found and cancellation was initiated, False otherwise.
         """
-        return self.__task_executor_queue.cancel_task(task_id)
+        self.__task_executor_queue.cancel_task(task_id)

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -4,8 +4,8 @@ Threaded Ewoks widget implementations.
 
 from __future__ import annotations
 
-import uuid
 import logging
+import uuid
 from contextlib import contextmanager
 from typing import Dict
 from typing import Optional

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -235,8 +235,9 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         )
         with self.__init_task_executor(task_executor, propagate):
             if task_executor.has_task:
+                task_id = str(uuid.uuid4())
                 with self._ewoks_task_start_context():
-                    task_id = task_executor.start()
+                    task_executor.start()
             else:
                 task_executor.finished.emit()
         return task_id

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -343,7 +343,11 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         return self.__last_output_variables
 
     def cancel_all_tasks(self):
-        raise NotImplementedError
+        task_exec_ids = [
+            task_exec_id for _, _, task_exec_id in self.__task_executors.values()
+        ]
+        for task_exec_id in task_exec_ids:
+            self.cancel_task(task_exec_id=task_exec_id)
 
     def cancel_task(self, task_exec_id: TaskExecutionID):
         self._cancel_running_task(task_exec_id)

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -11,6 +11,7 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 
+from ..concurrency._future import ExecutorFutureHandler
 from ..concurrency._future import TaskFuture
 from ..concurrency.base import TaskExecutionID
 from ..concurrency.queued import TaskExecutorQueue
@@ -97,10 +98,6 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
 
     def __onProgressChanged(self, progress: int):
         self.progressBarSet(float(progress))
-
-    def cancel_all_tasks(self) -> None:
-        """Subclasses should implement cancellation logic for their specific executors."""
-        raise NotImplementedError("Base class")
 
     def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         """Subclasses should implement cancellation logic for their specific executors."""
@@ -203,16 +200,14 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def _cancel_running_task(self):
         self.__task_executor._cancel_running_task()
 
-    def cancel_all_tasks(self) -> None:
-        # OWEwoksWidgetOneThread only supports one task at a time, so canceling all tasks is the same as canceling the running task.
-        self._cancel_running_task()
-
     def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         if task_exec_id == self._current_task_exec_id:
             self._cancel_running_task()
 
 
-class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
+class OWEwoksWidgetOneThreadPerRun(
+    _OWEwoksThreadedBaseWidget, ExecutorFutureHandler, **ow_build_opts
+):
     """
     Creates a new ThreadedTaskExecutor for every task run so multiple runs can overlap.
     """
@@ -258,7 +253,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     @contextmanager
     def __init_task_executor(
-        self, task_executor, propagate: bool, task_exec_id: TaskExecutionID
+        self, task_executor, propagate: bool, future: TaskExecutionID
     ):
         """
         Register a task executor and connect its finished callback for safe cleanup.
@@ -267,7 +262,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         :param propagate: Propagate flag to store with the executor.
         """
         task_executor.finished.connect(self._ewoks_task_finished_callback)
-        self.__add_task_executor(task_executor, propagate, task_exec_id)
+        self.__add_task_executor(task_executor, propagate, future)
         try:
             yield
         except Exception:
@@ -308,13 +303,13 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executors.clear()
 
     def __add_task_executor(
-        self, task_executor, propagate: bool, task_exec_id
+        self, task_executor, propagate: bool, future: TaskFuture
     ) -> TaskExecutionID:
         """Internal: register a new task executor with its propagate flag."""
         self.__task_executors[id(task_executor)] = (
             task_executor,
             propagate,
-            task_exec_id,
+            future,
         )
 
     def __remove_task_executor(self, task_executor: ThreadedTaskExecutor):
@@ -329,16 +324,13 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Return whether the given executor was registered to propagate."""
         return self.__task_executors.get(id(task_executor), (None, False, ""))[1]
 
-    def _get_task_executor(
-        self, task_exec_id: TaskExecutionID
-    ) -> ThreadedTaskExecutor | None:
+    def _get_task_executor(self, future: TaskFuture) -> ThreadedTaskExecutor | None:
         """Return outputs from the last finished task executor."""
         # FIXME: This lookup is inefficient; consider maintaining a separate dict mapping task_exec_id to executor for O(1) access if needed.
-        task_exec_id_to_executor = {
-            task_exec_id: executor
-            for executor, _, task_exec_id in self.__task_executors.values()
+        future_to_executor = {
+            future: executor for executor, _, future in self.__task_executors.values()
         }
-        return task_exec_id_to_executor.get(task_exec_id, None)
+        return future_to_executor.get(future, None)
 
     @property
     def task_succeeded(self) -> Optional[bool]:
@@ -356,20 +348,16 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Return the last finished task's outputs."""
         return self.__last_output_variables
 
-    def cancel_all_tasks(self) -> None:
-        task_exec_ids = [
-            task_exec_id for _, _, task_exec_id in self.__task_executors.values()
-        ]
-        for task_exec_id in task_exec_ids:
-            self.cancel_task(task_exec_id=task_exec_id)
+    def _cancel_future(self, future: TaskFuture) -> None:
+        """In the case of 'one thread per run' we can only abort."""
+        return False
 
-    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
-        self.__cancel_running_task(task_exec_id)
-
-    def __cancel_running_task(self, task_exec_id) -> None:
-        executor = self._get_task_executor(task_exec_id)
+    def _abort_future(self, future: TaskFuture) -> None:
+        executor = self._get_task_executor(future)
         if executor is not None:
             executor._cancel_running_task()
+            return True
+        return False
 
 
 class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
@@ -459,10 +447,6 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def _cancel_running_task(self):
         """Cancel the currently running task in the queue, if any."""
         self.__task_executor_queue._cancel_running_task()
-
-    def cancel_all_tasks(self) -> None:
-        """Cancel (or abort) all pending and running tasks in the queue."""
-        self.__task_executor_queue.cancel_all_tasks()
 
     def cancel_task(self, task_exec_id):
         """

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -10,8 +10,10 @@ from contextlib import contextmanager
 from typing import Dict
 from typing import Optional
 from typing import Tuple
+from concurrent.futures import InvalidStateError
 
 from ..concurrency.base import TaskExecutionID
+from ..concurrency._future import TaskFuture
 from ..concurrency.queued import TaskExecutorQueue
 from ..concurrency.threaded import ThreadedTaskExecutor
 from ..qt_utils.progress import QProgress
@@ -125,7 +127,7 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> TaskExecutionID:
+    ) -> TaskFuture:
         """
         Prepare and start the background thread if idle.
 
@@ -139,17 +141,23 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
+        future = TaskFuture(
+            task_exec_id=str(uuid.uuid4()),
+            executor=self.__task_executor,
+        )
+        future.task_kwargs = self._get_task_arguments()
         if self.__task_executor.has_task:
-            with self._ewoks_task_start_context():
+            with self._ewoks_task_start_context(future=future):
+                # TODO: add callback on the future.
                 self.__propagate = propagate
                 self.__task_executor.start()
-                self._current_task_exec_id = str(uuid.uuid4())
-                return self._current_task_exec_id
+                self._current_task_exec_id = future.task_exec_id
         else:
+            future.set_exception(InvalidStateError("Task already running."))
             self.__propagate = propagate
             self.__task_executor.finished.emit()
             self._current_task_exec_id = ""
-            return self._current_task_exec_id
+        return future
 
     @property
     def task_executor(self):
@@ -221,7 +229,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> TaskExecutionID:
+    ) -> TaskFuture:
         """
         Create a fresh ThreadedTaskExecutor, register it, and start it if it has work.
 
@@ -233,14 +241,17 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
-        task_exec_id = str(uuid.uuid4())
-        with self.__init_task_executor(task_executor, propagate, task_exec_id):
+        future = TaskFuture(
+            task_exec_id=str(uuid.uuid4()),
+            executor=self.__task_executors,
+        )
+        with self.__init_task_executor(task_executor, propagate, future):
             if task_executor.has_task:
                 with self._ewoks_task_start_context():
                     task_executor.start()
             else:
                 task_executor.finished.emit()
-        return task_exec_id
+        return future
 
     @contextmanager
     def __init_task_executor(
@@ -385,7 +396,7 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
-    ) -> TaskExecutionID:
+    ) -> TaskFuture:
         """
         Queue the task for later execution in FIFO order.
 
@@ -398,12 +409,12 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self._ewoks_task_finished_callback(propagate)
 
         with self._ewoks_task_start_context():
-            task_exec_id = self.__task_executor_queue.add(
+            future = self.__task_executor_queue.add(
                 _callbacks=(callback,),
                 _log_missing_inputs=log_missing_inputs,
                 **self._get_task_arguments(),
             )
-        return task_exec_id
+        return future
 
     @property
     def task_succeeded(self) -> Optional[bool]:

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -367,12 +367,15 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Access the underlying TaskExecutorQueue."""
         return self.__task_executor_queue
 
-    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> str:
+    def _execute_ewoks_task(
+        self, propagate: bool, log_missing_inputs: bool
+    ) -> tuple[bool, TaskExecutionID]:
         """
         Queue the task for later execution in FIFO order.
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
+        :return: Tuple indicating if the task was successfully queued and its execution ID.
         """
 
         def callback():
@@ -434,3 +437,12 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self.__task_executor_queue.get()
         # then cancel the currently running task, if any
         self.__task_executor_queue.cancel_all_tasks()
+
+    def cancel_task(self, task_id):
+        """
+        Cancel a specific task by ID, whether it's currently running or still in the queue.
+
+        :param task_id: The ID of the task to cancel.
+        :return: True if the task was found and cancellation was initiated, False otherwise.
+        """
+        return self.__task_executor_queue.cancel_task(task_id)

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -95,6 +95,14 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
     def __onProgressChanged(self, progress: int):
         self.progressBarSet(float(progress))
 
+    def cancel_all_tasks(self):
+        """Subclasses should implement cancellation logic for their specific executors."""
+        raise NotImplementedError("Base class")
+
+    def cancel_task(self, task_id):
+        """Subclasses should implement cancellation logic for their specific executors."""
+        raise NotImplementedError("Base class")
+
 
 class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     """

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -4,12 +4,14 @@ Threaded Ewoks widget implementations.
 
 from __future__ import annotations
 
+import uuid
 import logging
 from contextlib import contextmanager
 from typing import Dict
 from typing import Optional
 from typing import Tuple
 
+from ..concurrency.base import TaskExecutionID
 from ..concurrency.queued import TaskExecutorQueue
 from ..concurrency.threaded import ThreadedTaskExecutor
 from ..qt_utils.progress import QProgress
@@ -119,17 +121,21 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executor = ThreadedTaskExecutor(ewokstaskclass=self.ewokstaskclass)
         self.__task_executor.finished.connect(self._ewoks_task_finished_callback)
         self.__propagate = None
+        self._current_task_exec_id = ""
 
-    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> None:
+    def _execute_ewoks_task(
+        self, propagate: bool, log_missing_inputs: bool
+    ) -> tuple[bool, TaskExecutionID]:
         """
         Prepare and start the background thread if idle.
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
+        :return: Tuple indicating if the task was successfully queued and its execution ID.
         """
         if self.__task_executor.isRunning():
             _logger.error("A processing is already ongoing")
-            return
+            return False, ""
         self.__task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
@@ -137,9 +143,13 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             with self._ewoks_task_start_context():
                 self.__propagate = propagate
                 self.__task_executor.start()
+                self._current_task_exec_id = str(uuid.uuid4())
+                return True, self._current_task_exec_id
         else:
             self.__propagate = propagate
             self.__task_executor.finished.emit()
+            self._current_task_exec_id = ""
+            return False, self._current_task_exec_id
 
     @property
     def task_executor(self):
@@ -180,8 +190,15 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executor = None
 
     def cancel_running_task(self):
-        """Request cancellation of a running task."""
         self.__task_executor.cancel_running_task()
+
+    def cancel_all_tasks(self):
+        # OWEwoksWidgetOneThread only supports one task at a time, so canceling all tasks is the same as canceling the running task.
+        self.cancel_running_task()
+
+    def cancel_task(self, task_id):
+        if task_id == self._current_task_exec_id:
+            self.cancel_running_task()
 
 
 class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -101,7 +101,7 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
         """Subclasses should implement cancellation logic for their specific executors."""
         raise NotImplementedError("Base class")
 
-    def cancel_task(self, task_id):
+    def cancel_task(self, task_id: TaskExecutionID):
         """Subclasses should implement cancellation logic for their specific executors."""
         raise NotImplementedError("Base class")
 
@@ -196,7 +196,7 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         # OWEwoksWidgetOneThread only supports one task at a time, so canceling all tasks is the same as canceling the running task.
         self.cancel_running_task()
 
-    def cancel_task(self, task_id):
+    def cancel_task(self, task_id: TaskExecutionID):
         if task_id == self._current_task_exec_id:
             self.cancel_running_task()
 
@@ -340,7 +340,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def cancel_all_tasks(self):
         raise NotImplementedError
 
-    def cancel_task(self, task_id):
+    def cancel_task(self, task_id: TaskExecutionID):
         self._cancel_running_task(task_id)
 
     def _cancel_running_task(self, task_id):

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -97,11 +97,11 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
     def __onProgressChanged(self, progress: int):
         self.progressBarSet(float(progress))
 
-    def cancel_all_tasks(self):
+    def cancel_all_tasks(self) -> None:
         """Subclasses should implement cancellation logic for their specific executors."""
         raise NotImplementedError("Base class")
 
-    def cancel_task(self, task_exec_id: TaskExecutionID):
+    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         """Subclasses should implement cancellation logic for their specific executors."""
         raise NotImplementedError("Base class")
 
@@ -192,11 +192,11 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def cancel_running_task(self):
         self.__task_executor.cancel_running_task()
 
-    def cancel_all_tasks(self):
+    def cancel_all_tasks(self) -> None:
         # OWEwoksWidgetOneThread only supports one task at a time, so canceling all tasks is the same as canceling the running task.
         self.cancel_running_task()
 
-    def cancel_task(self, task_exec_id: TaskExecutionID):
+    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         if task_exec_id == self._current_task_exec_id:
             self.cancel_running_task()
 
@@ -342,17 +342,17 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Return the last finished task's outputs."""
         return self.__last_output_variables
 
-    def cancel_all_tasks(self):
+    def cancel_all_tasks(self) -> None:
         task_exec_ids = [
             task_exec_id for _, _, task_exec_id in self.__task_executors.values()
         ]
         for task_exec_id in task_exec_ids:
             self.cancel_task(task_exec_id=task_exec_id)
 
-    def cancel_task(self, task_exec_id: TaskExecutionID):
+    def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         self._cancel_running_task(task_exec_id)
 
-    def _cancel_running_task(self, task_exec_id):
+    def _cancel_running_task(self, task_exec_id) -> None:
         executor = self._get_task_executor(task_exec_id)
         if executor is not None:
             executor.cancel_running_task()
@@ -446,7 +446,7 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Cancel the currently running task in the queue, if any."""
         self.__task_executor_queue.cancel_running_task()
 
-    def cancel_all_tasks(self):
+    def cancel_all_tasks(self) -> None:
         """Cancel (or abort) all pending and running tasks in the queue."""
         self.__task_executor_queue.cancel_all_tasks()
 

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -211,18 +211,23 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         Initialize per-run executor storage.
         """
         super().__init__(*args, **kwargs)
-        self.__task_executors: Dict[int, Tuple[ThreadedTaskExecutor, bool]] = dict()
+        self.__task_executors: Dict[
+            int, Tuple[ThreadedTaskExecutor, bool, TaskExecutionID]
+        ] = dict()
         self.__last_output_variables = dict()
         self.__last_task_succeeded = None
         self.__last_task_done = None
         self.__last_task_exception = None
 
-    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> None:
+    def _execute_ewoks_task(
+        self, propagate: bool, log_missing_inputs: bool
+    ) -> tuple[bool, TaskExecutionID]:
         """
         Create a fresh ThreadedTaskExecutor, register it, and start it if it has work.
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
+        :return: Tuple indicating if the task was successfully queued and its execution ID.
         """
         task_executor = ThreadedTaskExecutor(ewokstaskclass=self.ewokstaskclass)
         task_executor.create_task(
@@ -231,9 +236,10 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         with self.__init_task_executor(task_executor, propagate):
             if task_executor.has_task:
                 with self._ewoks_task_start_context():
-                    task_executor.start()
+                    task_id = task_executor.start()
             else:
                 task_executor.finished.emit()
+        return True, task_id
 
     @contextmanager
     def __init_task_executor(self, task_executor, propagate: bool):
@@ -284,9 +290,11 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             task_executor.quit()
         self.__task_executors.clear()
 
-    def __add_task_executor(self, task_executor, propagate: bool):
+    def __add_task_executor(self, task_executor, propagate: bool) -> TaskExecutionID:
         """Internal: register a new task executor with its propagate flag."""
-        self.__task_executors[id(task_executor)] = task_executor, propagate
+        task_id = id(task_executor)
+        self.__task_executors[id(task_executor)] = task_executor, propagate, task_id
+        return task_id
 
     def __remove_task_executor(self, task_executor: ThreadedTaskExecutor):
         """Internal: unregister a task executor and disconnect its signals."""
@@ -298,7 +306,16 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
     def __is_task_executor_propagated(self, task_executor) -> bool:
         """Return whether the given executor was registered to propagate."""
-        return self.__task_executors.get(id(task_executor), (None, False))[1]
+        return self.__task_executors.get(id(task_executor), (None, False, ""))[1]
+
+    def _get_task_executor(
+        self, task_id: TaskExecutionID
+    ) -> ThreadedTaskExecutor | None:
+        """Return outputs from the last finished task executor."""
+        task_id_to_executor = {
+            task_id: executor for executor, _, task_id in self.__task_executors.values()
+        }
+        return task_id_to_executor.get(task_id, None)
 
     @property
     def task_succeeded(self) -> Optional[bool]:
@@ -315,6 +332,14 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def _get_task_outputs(self) -> dict:
         """Return the last finished task's outputs."""
         return self.__last_output_variables
+
+    def cancel_all_tasks(self):
+        raise NotImplementedError
+
+    def cancel_task(self, task_id):
+        executor = self._get_task_executor(task_id)
+        if executor is not None:
+            executor.cancel_running_task()
 
 
 class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -375,3 +375,11 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def cancel_running_task(self):
         """Cancel the currently running task in the queue, if any."""
         self.__task_executor_queue.cancel_running_task()
+
+    def cancel_all_tasks(self):
+        """Cancel all pending and running tasks in the queue."""
+        # first clear the queue of pending tasks
+        while not self.__task_executor_queue.empty():
+            self.__task_executor_queue.get()
+        # then cancel the currently running task, if any
+        self.__task_executor_queue.cancel_all_tasks()

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -233,9 +233,9 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
-        with self.__init_task_executor(task_executor, propagate):
+        task_id = str(uuid.uuid4())
+        with self.__init_task_executor(task_executor, propagate, task_id):
             if task_executor.has_task:
-                task_id = str(uuid.uuid4())
                 with self._ewoks_task_start_context():
                     task_executor.start()
             else:
@@ -243,7 +243,9 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         return task_id
 
     @contextmanager
-    def __init_task_executor(self, task_executor, propagate: bool):
+    def __init_task_executor(
+        self, task_executor, propagate: bool, task_id: TaskExecutionID
+    ):
         """
         Register a task executor and connect its finished callback for safe cleanup.
 
@@ -251,7 +253,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         :param propagate: Propagate flag to store with the executor.
         """
         task_executor.finished.connect(self._ewoks_task_finished_callback)
-        self.__add_task_executor(task_executor, propagate)
+        self.__add_task_executor(task_executor, propagate, task_id)
         try:
             yield
         except Exception:
@@ -291,11 +293,11 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             task_executor.quit()
         self.__task_executors.clear()
 
-    def __add_task_executor(self, task_executor, propagate: bool) -> TaskExecutionID:
+    def __add_task_executor(
+        self, task_executor, propagate: bool, task_id
+    ) -> TaskExecutionID:
         """Internal: register a new task executor with its propagate flag."""
-        task_id = id(task_executor)
         self.__task_executors[id(task_executor)] = task_executor, propagate, task_id
-        return task_id
 
     def __remove_task_executor(self, task_executor: ThreadedTaskExecutor):
         """Internal: unregister a task executor and disconnect its signals."""

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -10,10 +10,9 @@ from contextlib import contextmanager
 from typing import Dict
 from typing import Optional
 from typing import Tuple
-from concurrent.futures import InvalidStateError
 
-from ..concurrency.base import TaskExecutionID
 from ..concurrency._future import TaskFuture
+from ..concurrency.base import TaskExecutionID
 from ..concurrency.queued import TaskExecutorQueue
 from ..concurrency.threaded import ThreadedTaskExecutor
 from ..qt_utils.progress import QProgress
@@ -133,27 +132,31 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
-        :return: Tuple indicating if the task was successfully queued and its execution ID.
+        :return: Future of the task execution.
         """
-        if self.__task_executor.isRunning():
-            _logger.error("A processing is already ongoing")
-            return ""
-        self.__task_executor.create_task(
-            log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
-        )
         future = TaskFuture(
             task_exec_id=str(uuid.uuid4()),
             executor=self.__task_executor,
         )
+
+        if self.__task_executor.isRunning():
+            err = "A processing is already ongoing"
+            future.set_exception(RuntimeError(err))
+            _logger.error(err)
+            return future
+        self.__task_executor.create_task(
+            log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
+        )
         future.task_kwargs = self._get_task_arguments()
         if self.__task_executor.has_task:
-            with self._ewoks_task_start_context(future=future):
-                # TODO: add callback on the future.
+            with self._ewoks_task_start_context():
                 self.__propagate = propagate
                 self.__task_executor.start()
                 self._current_task_exec_id = future.task_exec_id
         else:
-            future.set_exception(InvalidStateError("Task already running."))
+            err = "Task undefined. Executor not correctly initialized."
+            future.set_exception(RuntimeError(err))
+            _logger.error(err)
             self.__propagate = propagate
             self.__task_executor.finished.emit()
             self._current_task_exec_id = ""
@@ -197,16 +200,16 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executor.stop()
         self.__task_executor = None
 
-    def cancel_running_task(self):
-        self.__task_executor.cancel_running_task()
+    def _cancel_running_task(self):
+        self.__task_executor._cancel_running_task()
 
     def cancel_all_tasks(self) -> None:
         # OWEwoksWidgetOneThread only supports one task at a time, so canceling all tasks is the same as canceling the running task.
-        self.cancel_running_task()
+        self._cancel_running_task()
 
     def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
         if task_exec_id == self._current_task_exec_id:
-            self.cancel_running_task()
+            self._cancel_running_task()
 
 
 class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
@@ -235,7 +238,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
-        :return: Tuple indicating if the task was successfully queued and its execution ID.
+        :return: Future of the task execution.
         """
         task_executor = ThreadedTaskExecutor(ewokstaskclass=self.ewokstaskclass)
         task_executor.create_task(
@@ -243,7 +246,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         )
         future = TaskFuture(
             task_exec_id=str(uuid.uuid4()),
-            executor=self.__task_executors,
+            executor=task_executor,
         )
         with self.__init_task_executor(task_executor, propagate, future):
             if task_executor.has_task:
@@ -361,12 +364,12 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self.cancel_task(task_exec_id=task_exec_id)
 
     def cancel_task(self, task_exec_id: TaskExecutionID) -> None:
-        self._cancel_running_task(task_exec_id)
+        self.__cancel_running_task(task_exec_id)
 
-    def _cancel_running_task(self, task_exec_id) -> None:
+    def __cancel_running_task(self, task_exec_id) -> None:
         executor = self._get_task_executor(task_exec_id)
         if executor is not None:
-            executor.cancel_running_task()
+            executor._cancel_running_task()
 
 
 class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
@@ -402,7 +405,7 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
-        :return: Tuple indicating if the task was successfully queued and its execution ID.
+        :return: Future of the task execution.
         """
 
         def callback():
@@ -453,9 +456,9 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             if propagate:
                 self.propagate_downstream()
 
-    def cancel_running_task(self):
+    def _cancel_running_task(self):
         """Cancel the currently running task in the queue, if any."""
-        self.__task_executor_queue.cancel_running_task()
+        self.__task_executor_queue._cancel_running_task()
 
     def cancel_all_tasks(self) -> None:
         """Cancel (or abort) all pending and running tasks in the queue."""

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -317,7 +317,7 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Access the underlying TaskExecutorQueue."""
         return self.__task_executor_queue
 
-    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> None:
+    def _execute_ewoks_task(self, propagate: bool, log_missing_inputs: bool) -> str:
         """
         Queue the task for later execution in FIFO order.
 
@@ -329,11 +329,12 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self._ewoks_task_finished_callback(propagate)
 
         with self._ewoks_task_start_context():
-            self.__task_executor_queue.add(
+            task_id = self.__task_executor_queue.add(
                 _callbacks=(callback,),
                 _log_missing_inputs=log_missing_inputs,
                 **self._get_task_arguments(),
             )
+        return task_id
 
     @property
     def task_succeeded(self) -> Optional[bool]:

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -312,6 +312,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self, task_id: TaskExecutionID
     ) -> ThreadedTaskExecutor | None:
         """Return outputs from the last finished task executor."""
+        # FIXME: This lookup is inefficient; consider maintaining a separate dict mapping task_id to executor for O(1) access if needed.
         task_id_to_executor = {
             task_id: executor for executor, _, task_id in self.__task_executors.values()
         }

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -101,7 +101,7 @@ class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
         """Subclasses should implement cancellation logic for their specific executors."""
         raise NotImplementedError("Base class")
 
-    def cancel_task(self, task_id: TaskExecutionID):
+    def cancel_task(self, task_exec_id: TaskExecutionID):
         """Subclasses should implement cancellation logic for their specific executors."""
         raise NotImplementedError("Base class")
 
@@ -196,8 +196,8 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         # OWEwoksWidgetOneThread only supports one task at a time, so canceling all tasks is the same as canceling the running task.
         self.cancel_running_task()
 
-    def cancel_task(self, task_id: TaskExecutionID):
-        if task_id == self._current_task_exec_id:
+    def cancel_task(self, task_exec_id: TaskExecutionID):
+        if task_exec_id == self._current_task_exec_id:
             self.cancel_running_task()
 
 
@@ -233,18 +233,18 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
-        task_id = str(uuid.uuid4())
-        with self.__init_task_executor(task_executor, propagate, task_id):
+        task_exec_id = str(uuid.uuid4())
+        with self.__init_task_executor(task_executor, propagate, task_exec_id):
             if task_executor.has_task:
                 with self._ewoks_task_start_context():
                     task_executor.start()
             else:
                 task_executor.finished.emit()
-        return task_id
+        return task_exec_id
 
     @contextmanager
     def __init_task_executor(
-        self, task_executor, propagate: bool, task_id: TaskExecutionID
+        self, task_executor, propagate: bool, task_exec_id: TaskExecutionID
     ):
         """
         Register a task executor and connect its finished callback for safe cleanup.
@@ -253,7 +253,7 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         :param propagate: Propagate flag to store with the executor.
         """
         task_executor.finished.connect(self._ewoks_task_finished_callback)
-        self.__add_task_executor(task_executor, propagate, task_id)
+        self.__add_task_executor(task_executor, propagate, task_exec_id)
         try:
             yield
         except Exception:
@@ -294,10 +294,14 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__task_executors.clear()
 
     def __add_task_executor(
-        self, task_executor, propagate: bool, task_id
+        self, task_executor, propagate: bool, task_exec_id
     ) -> TaskExecutionID:
         """Internal: register a new task executor with its propagate flag."""
-        self.__task_executors[id(task_executor)] = task_executor, propagate, task_id
+        self.__task_executors[id(task_executor)] = (
+            task_executor,
+            propagate,
+            task_exec_id,
+        )
 
     def __remove_task_executor(self, task_executor: ThreadedTaskExecutor):
         """Internal: unregister a task executor and disconnect its signals."""
@@ -312,14 +316,15 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         return self.__task_executors.get(id(task_executor), (None, False, ""))[1]
 
     def _get_task_executor(
-        self, task_id: TaskExecutionID
+        self, task_exec_id: TaskExecutionID
     ) -> ThreadedTaskExecutor | None:
         """Return outputs from the last finished task executor."""
-        # FIXME: This lookup is inefficient; consider maintaining a separate dict mapping task_id to executor for O(1) access if needed.
-        task_id_to_executor = {
-            task_id: executor for executor, _, task_id in self.__task_executors.values()
+        # FIXME: This lookup is inefficient; consider maintaining a separate dict mapping task_exec_id to executor for O(1) access if needed.
+        task_exec_id_to_executor = {
+            task_exec_id: executor
+            for executor, _, task_exec_id in self.__task_executors.values()
         }
-        return task_id_to_executor.get(task_id, None)
+        return task_exec_id_to_executor.get(task_exec_id, None)
 
     @property
     def task_succeeded(self) -> Optional[bool]:
@@ -340,11 +345,11 @@ class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     def cancel_all_tasks(self):
         raise NotImplementedError
 
-    def cancel_task(self, task_id: TaskExecutionID):
-        self._cancel_running_task(task_id)
+    def cancel_task(self, task_exec_id: TaskExecutionID):
+        self._cancel_running_task(task_exec_id)
 
-    def _cancel_running_task(self, task_id):
-        executor = self._get_task_executor(task_id)
+    def _cancel_running_task(self, task_exec_id):
+        executor = self._get_task_executor(task_exec_id)
         if executor is not None:
             executor.cancel_running_task()
 
@@ -389,12 +394,12 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self._ewoks_task_finished_callback(propagate)
 
         with self._ewoks_task_start_context():
-            task_id = self.__task_executor_queue.add(
+            task_exec_id = self.__task_executor_queue.add(
                 _callbacks=(callback,),
                 _log_missing_inputs=log_missing_inputs,
                 **self._get_task_arguments(),
             )
-        return task_id
+        return task_exec_id
 
     @property
     def task_succeeded(self) -> Optional[bool]:
@@ -441,11 +446,11 @@ class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """Cancel (or abort) all pending and running tasks in the queue."""
         self.__task_executor_queue.cancel_all_tasks()
 
-    def cancel_task(self, task_id):
+    def cancel_task(self, task_exec_id):
         """
         Cancel a specific task by ID, whether it's currently running or still in the queue.
 
-        :param task_id: The ID of the task to cancel.
+        :param task_exec_id: The ID of the task to cancel.
         :return: True if the task was found and cancellation was initiated, False otherwise.
         """
-        self.__task_executor_queue.cancel_task(task_id)
+        self.__task_executor_queue.cancel_task(task_exec_id)

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -7,14 +7,13 @@ from __future__ import annotations
 import logging
 import uuid
 from contextlib import contextmanager
-from typing import Dict
 from typing import Optional
-from typing import Tuple
 
 from ..concurrency._Executor import AbortableExecutor, CancellableExecutor
 from ..concurrency._future import TaskFuture
 from ..concurrency.base import TaskExecutionID
 from ..concurrency.queued import TaskExecutorQueue
+from ..concurrency.threaded import MultiThreadedTaskExecutor
 from ..concurrency.threaded import ThreadedTaskExecutor
 from ..qt_utils.progress import QProgress
 from .base import OWEwoksBaseWidget
@@ -131,17 +130,7 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         :param log_missing_inputs: Whether to log missing input warnings.
         :return: Future of the task execution.
         """
-        future = TaskFuture(
-            task_exec_id=str(uuid.uuid4()),
-            executor=self.__task_executor,
-        )
-
-        if self.__task_executor.isRunning():
-            err = "A processing is already ongoing"
-            future.set_exception(RuntimeError(err))
-            _logger.error(err)
-            return future
-        self.__task_executor.create_task(
+        future = self.__task_executor.create_task(
             log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
         )
         future.task_kwargs = self._get_task_arguments()
@@ -205,163 +194,80 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
             self._cancel_running_task()
 
 
-class OWEwoksWidgetOneThreadPerRun(
-    _OWEwoksThreadedBaseWidget, AbortableExecutor, CancellableExecutor, **ow_build_opts
-):
+class OWEwoksWidgetOneThreadPerRun(_OWEwoksThreadedBaseWidget, **ow_build_opts):
     """
     Creates a new ThreadedTaskExecutor for every task run so multiple runs can overlap.
     """
 
     def __init__(self, *args, **kwargs):
         """
-        Initialize per-run executor storage.
+        Initialize the multi-thread task executor.
         """
         super().__init__(*args, **kwargs)
-        self.__task_executors: Dict[
-            int, Tuple[ThreadedTaskExecutor, bool, TaskExecutionID]
-        ] = dict()
-        self.__last_output_variables = dict()
-        self.__last_task_succeeded = None
-        self.__last_task_done = None
-        self.__last_task_exception = None
+        self.__task_executor = MultiThreadedTaskExecutor(
+            ewokstaskclass=self.ewokstaskclass
+        )
 
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
     ) -> TaskFuture:
         """
-        Create a fresh ThreadedTaskExecutor, register it, and start it if it has work.
+        Submit a task to the multi-thread executor.
 
         :param propagate: Whether to propagate outputs after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
         :return: Future of the task execution.
         """
-        task_executor = ThreadedTaskExecutor(ewokstaskclass=self.ewokstaskclass)
-        task_executor.create_task(
-            log_missing_inputs=log_missing_inputs, **self._get_task_arguments()
-        )
-        future = TaskFuture(
-            task_exec_id=str(uuid.uuid4()),
-            executor=self,
-        )
-        with self.__init_task_executor(task_executor, propagate, future):
-            if task_executor.has_task:
-                with self._ewoks_task_start_context():
-                    task_executor.start()
-            else:
-                task_executor.finished.emit()
-        return future
+        with self._ewoks_task_start_context():
+            self.__task_executor.create_task(
+                _callbacks=(
+                    lambda task_executor, future: self._ewoks_task_finished_callback(
+                        task_executor, propagate
+                    ),
+                ),
+                log_missing_inputs=log_missing_inputs,
+                **self._get_task_arguments(),
+            )
+            return self.__task_executor.execute_task()
 
-    @contextmanager
-    def __init_task_executor(
-        self, task_executor, propagate: bool, future: TaskExecutionID
+    def _ewoks_task_finished_callback(
+        self, task_executor: ThreadedTaskExecutor, propagate: bool
     ):
-        """
-        Register a task executor and connect its finished callback for safe cleanup.
-
-        :param task_executor: The ThreadedTaskExecutor instance.
-        :param propagate: Propagate flag to store with the executor.
-        """
-        task_executor.finished.connect(self._ewoks_task_finished_callback)
-        self.__add_task_executor(task_executor, propagate, future)
-        try:
-            yield
-        except Exception:
-            task_executor.finished.disconnect(self._ewoks_task_finished_callback)
-            self.__remove_task_executor(task_executor)
-            raise
-
-    def __disconnect_all_task_executors(self):
-        """Disconnect all connected finished signals from tracked executors."""
-        for task_executor, _ in self.__task_executors.values():
-            if task_executor.receivers(task_executor.finished) > 0:
-                task_executor.finished.disconnect(self._ewoks_task_finished_callback)
-
-    def _ewoks_task_finished_callback(self):
         """
         Slot invoked when a per-run executor finishes; stores its outputs and optionally propagates.
         """
         with self._ewoks_task_finished_context():
-            task_executor = None
-            try:
-                task_executor = self.sender()
-
-                future: TaskFuture = self.__task_executors[id(task_executor)][2]
-                future.set_result(task_executor.current_task.get_output_values())
-
-                self.__last_output_variables = task_executor.output_variables
-                self.__last_task_succeeded = task_executor.succeeded
-                self.__last_task_done = task_executor.done
-                self.__last_task_exception = task_executor.exception
-                self.__post_task_exception = None
-                propagate = self.__is_task_executor_propagated(task_executor)
-                if propagate:
-                    self.propagate_downstream(succeeded=task_executor.succeeded)
-            finally:
-                self.__remove_task_executor(task_executor)
+            self.__post_task_exception = None
+            if propagate:
+                self.propagate_downstream(succeeded=task_executor.succeeded)
 
     def _cleanup_task_executor(self):
-        """Disconnect and quit all tracked executors on widget cleanup."""
-        self.__disconnect_all_task_executors()
-        for task_executor, _ in self.__task_executors.values():
-            task_executor.quit()
-        self.__task_executors.clear()
-
-    def __add_task_executor(
-        self, task_executor, propagate: bool, future: TaskFuture
-    ) -> TaskExecutionID:
-        """Internal: register a new task executor with its propagate flag."""
-        self.__task_executors[id(task_executor)] = (
-            task_executor,
-            propagate,
-            future,
-        )
-
-    def __remove_task_executor(self, task_executor: ThreadedTaskExecutor):
-        """Internal: unregister a task executor and disconnect its signals."""
-        if task_executor is None:
-            return
-        if task_executor.receivers(task_executor.finished) > 0:
-            task_executor.finished.disconnect(self._ewoks_task_finished_callback)
-        self.__task_executors.pop(id(task_executor), None)
-
-    def __is_task_executor_propagated(self, task_executor) -> bool:
-        """Return whether the given executor was registered to propagate."""
-        return self.__task_executors.get(id(task_executor), (None, False, ""))[1]
-
-    def _get_task_executor(self, future: TaskFuture) -> ThreadedTaskExecutor | None:
-        """Return outputs from the last finished task executor."""
-        # FIXME: This lookup is inefficient; consider maintaining a separate dict mapping task_exec_id to executor for O(1) access if needed.
-        future_to_executor = {
-            future: executor for executor, _, future in self.__task_executors.values()
-        }
-        return future_to_executor.get(future, None)
+        """Stop all tracked per-run executors on widget cleanup."""
+        self.__task_executor.stop()
+        self.__task_executor = None
 
     @property
     def task_succeeded(self) -> Optional[bool]:
-        return self.__last_task_succeeded
+        return self.__task_executor.task_succeeded
 
     @property
     def task_done(self) -> Optional[bool]:
-        return self.__last_task_done
+        return self.__task_executor.task_done
 
     @property
     def task_exception(self) -> Optional[Exception]:
-        return self.__last_task_exception
+        return self.__task_executor.task_exception
 
     def _get_task_outputs(self) -> dict:
         """Return the last finished task's outputs."""
-        return self.__last_output_variables
+        return self.__task_executor.output_variables
 
     def _cancel_future(self, future: TaskFuture) -> None:
         """In the case of 'one thread per run' we can only abort."""
         return False
 
     def _abort_future(self, future: TaskFuture) -> None:
-        executor = self._get_task_executor(future)
-        if executor is not None:
-            executor._abort_future(future=future)
-            return True
-        return False
+        return self.__task_executor._abort_future(future)
 
 
 class OWEwoksWidgetWithTaskStack(_OWEwoksThreadedBaseWidget, **ow_build_opts):

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -11,7 +11,7 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 
-from ..concurrency._future import ExecutorFutureHandler
+from ..concurrency._Executor import AbortableExecutor, CancellableExecutor
 from ..concurrency._future import TaskFuture
 from ..concurrency.base import TaskExecutionID
 from ..concurrency.queued import TaskExecutorQueue
@@ -206,7 +206,7 @@ class OWEwoksWidgetOneThread(_OWEwoksThreadedBaseWidget, **ow_build_opts):
 
 
 class OWEwoksWidgetOneThreadPerRun(
-    _OWEwoksThreadedBaseWidget, ExecutorFutureHandler, **ow_build_opts
+    _OWEwoksThreadedBaseWidget, AbortableExecutor, CancellableExecutor, **ow_build_opts
 ):
     """
     Creates a new ThreadedTaskExecutor for every task run so multiple runs can overlap.
@@ -241,7 +241,7 @@ class OWEwoksWidgetOneThreadPerRun(
         )
         future = TaskFuture(
             task_exec_id=str(uuid.uuid4()),
-            executor=task_executor,
+            executor=self,
         )
         with self.__init_task_executor(task_executor, propagate, future):
             if task_executor.has_task:
@@ -284,6 +284,10 @@ class OWEwoksWidgetOneThreadPerRun(
             task_executor = None
             try:
                 task_executor = self.sender()
+
+                future: TaskFuture = self.__task_executors[id(task_executor)][2]
+                future.set_result(task_executor.current_task.get_output_values())
+
                 self.__last_output_variables = task_executor.output_variables
                 self.__last_task_succeeded = task_executor.succeeded
                 self.__last_task_done = task_executor.done
@@ -355,7 +359,7 @@ class OWEwoksWidgetOneThreadPerRun(
     def _abort_future(self, future: TaskFuture) -> None:
         executor = self._get_task_executor(future)
         if executor is not None:
-            executor._cancel_running_task()
+            executor._abort_future(future=future)
             return True
         return False
 

--- a/src/ewoksorange/tests/examples/tasks.py
+++ b/src/ewoksorange/tests/examples/tasks.py
@@ -12,7 +12,6 @@ class PrintSum(Task, input_names=["sum"]):
     def run(self):
         if self.inputs.sum is None:
             raise ValueError("'value' should be provided")
-        print("input value is", self.inputs.sum)
 
 
 class SumList1(SumList):

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -1,6 +1,8 @@
+from time import sleep
+
+import pytest
 from ewokscore import Task
 
-from time import sleep
 from ..gui.owwidgets.meta import ow_build_opts
 from ..gui.owwidgets.threaded import (
     OWEwoksWidgetOneThreadPerRun as _OWEwoksWidgetOneThreadPerRun,
@@ -52,7 +54,14 @@ class OWEwoksWidgetOneThreadPerRun(
     name = "test_OW"
 
 
-def test_OWEwoksWidgetOneThreadPerRun(qtapp):
+@pytest.mark.parametrize(
+    "test_case, expected_values",
+    [
+        ("standard_execution", [0, 1, 2]),
+        ("cancellation", ["cancelled", "cancelled", "cancelled"]),
+    ],
+)
+def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
     """
     Test processing several tasks.
     The widget will create one thread per task and execution will be done in parallel.
@@ -66,50 +75,22 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp):
         MyObject(),
     )
 
-    for value, obj in enumerate(objects):
-        widget.set_dynamic_input("value", value)
-        widget.set_dynamic_input("my_object", obj)
-
-        # Start calculation
-        widget.handleNewSignals()
-
-    for obj in objects:
-        obj.finished.wait(timeout=3)
-
-    values = [obj.value for obj in objects]
-    expected = [0, 1, 2]
-    assert values == expected
-
-
-def test_OWEwoksWidgetOneThreadPerRun_cancellation(qtapp):
-    # test task cancellation
-    widget = OWEwoksWidgetOneThreadPerRun()
-
-    objects = (
-        MyObject(),
-        MyObject(),
-        MyObject(),
-    )
     execution_ids = []
-
     for value, obj in enumerate(objects):
         widget.set_dynamic_input("value", value)
         widget.set_dynamic_input("my_object", obj)
-        widget.set_dynamic_input("sleep_duration", 0.5)
+        if test_case == "cancellation":
+            widget.set_dynamic_input("sleep_duration", 0.5)
 
         # Start calculation
-        task_exec_id = widget.execute_ewoks_task()
-        execution_ids.append(task_exec_id)
-        assert task_exec_id not in ("", None)
+        execution_ids.append(widget.execute_ewoks_task())
 
-    for exec_id in execution_ids:
-        widget.cancel_task(exec_id)
+    if test_case == "cancellation":
+        for exec_id in execution_ids:
+            widget.cancel_task(exec_id)
 
     for obj in objects:
         obj.finished.wait(timeout=3)
 
-    # The task is not implemented the `cancel` method,
-    # so the first task will be executed and the others will be cancelled.
     values = [obj.value for obj in objects]
-    expected = ["cancelled", "cancelled", "cancelled"]
-    assert values == expected
+    assert values == expected_values

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -1,5 +1,6 @@
 from ewokscore import Task
 
+from time import sleep
 from ..gui.owwidgets.meta import ow_build_opts
 from ..gui.owwidgets.threaded import (
     OWEwoksWidgetOneThreadPerRun as _OWEwoksWidgetOneThreadPerRun,
@@ -19,15 +20,28 @@ class MyObject:
 class DummyTask(
     Task,
     input_names=("my_object", "value"),
+    optional_input_names=("sleep_duration",),
     output_names=("my_object",),
 ):
     """Task that set a value to MyObject and set a 'finished' Event"""
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__cancelled = False
+
     def run(self):
+        sleep(self.input_values.get("sleep_duration", 0))
         my_object = self.inputs.my_object
-        my_object.value = self.inputs.value
+
+        if self.__cancelled:
+            my_object.value = "cancelled"
+        else:
+            my_object.value = self.inputs.value
         self.outputs.my_object = my_object
         my_object.finished_callback()
+
+    def cancel(self):
+        self.__cancelled = True
 
 
 class OWEwoksWidgetOneThreadPerRun(
@@ -64,4 +78,38 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp):
 
     values = [obj.value for obj in objects]
     expected = [0, 1, 2]
+    assert values == expected
+
+
+def test_OWEwoksWidgetOneThreadPerRun_cancellation(qtapp):
+    # test task cancellation
+    widget = OWEwoksWidgetOneThreadPerRun()
+
+    objects = (
+        MyObject(),
+        MyObject(),
+        MyObject(),
+    )
+    execution_ids = []
+
+    for value, obj in enumerate(objects):
+        widget.set_dynamic_input("value", value)
+        widget.set_dynamic_input("my_object", obj)
+        widget.set_dynamic_input("sleep_duration", 0.5)
+
+        # Start calculation
+        task_exec_id = widget.execute_ewoks_task()
+        execution_ids.append(task_exec_id)
+        assert task_exec_id not in ("", None)
+
+    for exec_id in execution_ids:
+        widget.cancel_task(exec_id)
+
+    for obj in objects:
+        obj.finished.wait(timeout=3)
+
+    # The task is not implemented the `cancel` method,
+    # so the first task will be executed and the others will be cancelled.
+    values = [obj.value for obj in objects]
+    expected = ["cancelled", "cancelled", "cancelled"]
     assert values == expected

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -1,7 +1,6 @@
 from time import sleep
 
 import pytest
-from ewokscore import Task
 
 from ..gui.owwidgets.meta import ow_build_opts
 from ..gui.owwidgets.threaded import (
@@ -32,8 +31,7 @@ class OWEwoksWidgetOneThreadPerRun(
     "test_case, expected_values",
     [
         ("standard_execution", [0, 1, 2]),
-        ("cancellation_task_by_task", ["cancelled", "cancelled", "cancelled"]),
-        ("cancellation_all_tasks", ["cancelled", "cancelled", "cancelled"]),
+        ("cancel_futures", ["cancelled", "cancelled", "cancelled"]),
     ],
 )
 def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
@@ -54,17 +52,15 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
     for value, obj in enumerate(objects):
         widget.set_dynamic_input("value", value)
         widget.set_dynamic_input("my_object", obj)
-        if test_case in ("cancellation_task_by_task", "cancellation_all_tasks"):
+        if test_case == "cancel_futures":
             widget.set_dynamic_input("sleep_duration", 0.5)
 
         # Start calculation
         futures.append(widget.execute_ewoks_task())
 
-    if test_case == "cancellation_task_by_task":
-        for exec_id in futures:
-            widget.cancel_task(exec_id)
-    elif test_case == "cancellation_all_tasks":
-        widget.cancel_all_tasks()
+    if test_case == "cancel_futures":
+        for future in futures:
+            assert future.abort(), f"Future cannot be aborted."
 
     for obj in objects:
         obj.finished.wait(timeout=3)

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -8,6 +8,7 @@ from ..gui.owwidgets.threaded import (
     OWEwoksWidgetOneThreadPerRun as _OWEwoksWidgetOneThreadPerRun,
 )
 from ..gui.qt_utils.app import QtEvent
+from .utils import DummyTask
 
 
 class MyObject:
@@ -17,33 +18,6 @@ class MyObject:
 
     def finished_callback(self):
         self.finished.set()
-
-
-class DummyTask(
-    Task,
-    input_names=("my_object", "value"),
-    optional_input_names=("sleep_duration",),
-    output_names=("my_object",),
-):
-    """Task that set a value to MyObject and set a 'finished' Event"""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.__cancelled = False
-
-    def run(self):
-        sleep(self.input_values.get("sleep_duration", 0))
-        my_object = self.inputs.my_object
-
-        if self.__cancelled:
-            my_object.value = "cancelled"
-        else:
-            my_object.value = self.inputs.value
-        self.outputs.my_object = my_object
-        my_object.finished_callback()
-
-    def cancel(self):
-        self.__cancelled = True
 
 
 class OWEwoksWidgetOneThreadPerRun(

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -58,7 +58,8 @@ class OWEwoksWidgetOneThreadPerRun(
     "test_case, expected_values",
     [
         ("standard_execution", [0, 1, 2]),
-        ("cancellation", ["cancelled", "cancelled", "cancelled"]),
+        ("cancellation_task_by_task", ["cancelled", "cancelled", "cancelled"]),
+        ("cancellation_all_tasks", ["cancelled", "cancelled", "cancelled"]),
     ],
 )
 def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
@@ -79,15 +80,17 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
     for value, obj in enumerate(objects):
         widget.set_dynamic_input("value", value)
         widget.set_dynamic_input("my_object", obj)
-        if test_case == "cancellation":
+        if test_case in ("cancellation_task_by_task", "cancellation_all_tasks"):
             widget.set_dynamic_input("sleep_duration", 0.5)
 
         # Start calculation
         execution_ids.append(widget.execute_ewoks_task())
 
-    if test_case == "cancellation":
+    if test_case == "cancellation_task_by_task":
         for exec_id in execution_ids:
             widget.cancel_task(exec_id)
+    elif test_case == "cancellation_all_tasks":
+        widget.cancel_all_tasks()
 
     for obj in objects:
         obj.finished.wait(timeout=3)

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -50,7 +50,7 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
         MyObject(),
     )
 
-    execution_ids = []
+    futures = []
     for value, obj in enumerate(objects):
         widget.set_dynamic_input("value", value)
         widget.set_dynamic_input("my_object", obj)
@@ -58,10 +58,10 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
             widget.set_dynamic_input("sleep_duration", 0.5)
 
         # Start calculation
-        execution_ids.append(widget.execute_ewoks_task())
+        futures.append(widget.execute_ewoks_task())
 
     if test_case == "cancellation_task_by_task":
-        for exec_id in execution_ids:
+        for exec_id in futures:
             widget.cancel_task(exec_id)
     elif test_case == "cancellation_all_tasks":
         widget.cancel_all_tasks()

--- a/src/ewoksorange/tests/test_OneThreadPerRun.py
+++ b/src/ewoksorange/tests/test_OneThreadPerRun.py
@@ -28,13 +28,23 @@ class OWEwoksWidgetOneThreadPerRun(
 
 
 @pytest.mark.parametrize(
-    "test_case, expected_values",
+    "test_case, expected_obj_values, expected_future_values",
     [
-        ("standard_execution", [0, 1, 2]),
-        ("cancel_futures", ["cancelled", "cancelled", "cancelled"]),
+        (
+            "standard_execution",
+            [0, 1, 2],
+            [0, 1, 2],
+        ),
+        (
+            "cancel_futures",
+            ["cancelled", "cancelled", "cancelled"],
+            [Exception, Exception, Exception],
+        ),
     ],
 )
-def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
+def test_OWEwoksWidgetOneThreadPerRun(
+    qtapp, test_case, expected_obj_values, expected_future_values
+):
     """
     Test processing several tasks.
     The widget will create one thread per task and execution will be done in parallel.
@@ -59,11 +69,22 @@ def test_OWEwoksWidgetOneThreadPerRun(qtapp, test_case, expected_values):
         futures.append(widget.execute_ewoks_task())
 
     if test_case == "cancel_futures":
+        # wait for the future to be started. Should be done through a QtEvent
+        sleep(0.2)
         for future in futures:
-            assert future.abort(), f"Future cannot be aborted."
-
+            assert future.abort(), "Future cannot be aborted."
     for obj in objects:
         obj.finished.wait(timeout=3)
 
     values = [obj.value for obj in objects]
-    assert values == expected_values
+    assert values == expected_obj_values
+
+    for future, expected_future_value in zip(futures, expected_future_values):
+        assert future.done(), "future is done"
+        if expected_future_value is Exception:
+            assert future.exception() is not None
+        else:
+            assert future.exception() is None
+            assert (
+                future.result()["my_object"].value == expected_future_value
+            ), f"future result is {future.result()!r} when {expected_future_value!r} expected."

--- a/src/ewoksorange/tests/test_nothread.py
+++ b/src/ewoksorange/tests/test_nothread.py
@@ -1,0 +1,56 @@
+from time import sleep
+
+import pytest
+from ewokscore import Task
+
+from ..gui.owwidgets.meta import ow_build_opts
+from ..gui.owwidgets.nothread import (
+    OWEwoksWidgetNoThread as _OWEwoksWidgetNoThread,
+)
+from ..gui.qt_utils.app import QtEvent
+from .utils import DummyTask
+
+
+class MyObject:
+    def __init__(self):
+        self.value = None
+        self.finished = QtEvent()
+
+    def finished_callback(self):
+        self.finished.set()
+
+
+class OWEwoksWidgetNoThread(
+    _OWEwoksWidgetNoThread,
+    **ow_build_opts,
+    ewokstaskclass=DummyTask,
+):
+    name = "test_OW"
+
+
+def test_OWEwoksWidgetNoThread(qtapp):
+    """
+    Test processing of two tasks.
+    The first task will be executed, prevent any other execution of code. Then the second will aldo be executed.
+    """
+    widget = OWEwoksWidgetNoThread()
+
+    objects = (
+        MyObject(),
+        MyObject(),
+    )
+
+    futures = []
+    for value, obj in enumerate(objects):
+        widget.set_dynamic_input("value", value)
+        widget.set_dynamic_input("my_object", obj)
+        widget.set_dynamic_input("sleep_duration", 0.5)
+
+        # Start calculation
+        futures.append(widget.execute_ewoks_task())
+
+    future_task, concurrent_future_task = futures
+
+    assert "my_object" in future_task.result()
+    assert future_task.task_exec_id != concurrent_future_task.task_exec_id
+    assert "my_object" in concurrent_future_task.result()

--- a/src/ewoksorange/tests/test_nothread.py
+++ b/src/ewoksorange/tests/test_nothread.py
@@ -4,9 +4,7 @@ import pytest
 from ewokscore import Task
 
 from ..gui.owwidgets.meta import ow_build_opts
-from ..gui.owwidgets.nothread import (
-    OWEwoksWidgetNoThread as _OWEwoksWidgetNoThread,
-)
+from ..gui.owwidgets.nothread import OWEwoksWidgetNoThread as _OWEwoksWidgetNoThread
 from ..gui.qt_utils.app import QtEvent
 from .utils import DummyTask
 

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -5,7 +5,7 @@ from ewokscore import Task
 from ewokscore.missing_data import MISSING_DATA
 from ewokscore.tests.examples.tasks.sumtask import SumTask
 
-from ..gui.concurrency.base import TaskExecutor
+from ..gui.concurrency.base import TaskExecutor, TaskExecutionID
 from ..gui.concurrency.queued import TaskExecutorQueue
 from ..gui.concurrency.threaded import ThreadedTaskExecutor
 from ..gui.qt_utils.app import QtEvent
@@ -20,10 +20,15 @@ def test_task_executor():
     assert executor.has_task
     assert not executor.succeeded
 
-    executor.execute_task()
+    task_exec_id = executor.execute_task()
+    assert task_exec_id not in ("", None) and isinstance(task_exec_id, TaskExecutionID)
     assert executor.succeeded
     results = {k: v.value for k, v in executor.output_variables.items()}
     assert results == {"result": 3}
+
+    # dummy test of the API
+    executor.cancel_task(task_id=task_exec_id)
+    executor.cancel_all_tasks()
 
 
 def test_threaded_task_executor(qtapp):

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -1,6 +1,6 @@
+import threading
 import time
 
-import pytest
 from AnyQt.QtCore import QObject
 from ewokscore import Task
 from ewokscore.missing_data import MISSING_DATA
@@ -33,9 +33,8 @@ def test_task_executor():
     assert future_task.exception() is None
 
     # dummy test of the API
-    executor.cancel_task(task_exec_id=future_task.task_exec_id)
-    executor.cancel_all_tasks()
     assert future_task.cancel() is False
+    assert future_task.abort() is False
 
 
 def test_threaded_task_executor(qtapp):
@@ -108,12 +107,23 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
             self.finished.set()
 
     class InfiniteTask(Task, input_names=["duration"], output_names=["result"]):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._cancel_event = threading.Event()
+
         def run(self):
-            time.sleep(self.inputs.duration)
+            remaining_sleeping_time = self.inputs.duration
+            while remaining_sleeping_time > 0:
+                remaining_sleeping_time -= 1
+                if self._cancel_event.is_set():
+                    return
+                time.sleep(1)
+
             self.outputs.result = f"have waited {self.inputs.duration}s"
 
         def cancel(self):
-            self._cancel = True
+            self._cancel_event.set()
+            self.cancelled = True
 
     executor = TaskExecutorQueue(ewokstaskclass=InfiniteTask)
 
@@ -125,25 +135,35 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
     # expected behavior:
     # the first task is cancelled (so result is MISSING_DATA)
     # then the second task is executed (results is 'have waited 1s')
-    executor.add(
+    future_1 = executor.add(
         inputs={
-            "duration": 100,
+            "duration": 10,
         },
         _callbacks=(obj1.finished_callback,),
     )
-    executor.add(
+    future_2 = executor.add(
         inputs={
             "duration": 1,
         },
         _callbacks=(obj2.finished_callback,),
     )
+    future_3 = executor.add(
+        inputs={
+            "duration": 5,
+        },
+        _callbacks=(obj3.finished_callback,),
+    )
+
     assert not executor.is_available
-    # cancel obj 1
-    executor._cancel_running_task(wait=False)
-    assert obj2.finished.wait(timeout=30)
-    assert obj1.results["result"] is MISSING_DATA
+    # cancel future_1
+    assert future_1.abort()
+    assert future_3.cancel()
+
+    assert obj2.finished.wait(timeout=2)
     assert executor.is_available
+    assert obj1.results["result"] is MISSING_DATA
     assert obj2.results["result"] == "have waited 1s"
+    assert obj3.results is None
 
     # then try to sending an new job
     executor.add(
@@ -163,23 +183,23 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
 
     obj4_future = executor.add(
         inputs={
-            "duration": 2,
+            "duration": 5,
         },
         _callbacks=(obj4.finished_callback,),
     )
     obj5_future = executor.add(
         inputs={
-            "duration": 2,
+            "duration": 1,
         },
         _callbacks=(obj5.finished_callback,),
     )
     assert obj4_future.running()
-    assert obj4_future.cancel(), "future cancellation failed"
+    assert not obj4_future.cancel(), "can cancel an on-going task"
+    assert obj4_future.abort()
 
     len(executor._task_queue) == 1
     remaining_futures = list(executor._task_futures.keys()) + [
         executor._current_task_future,
     ]
     assert obj5_future in remaining_futures
-    executor.cancel_all_tasks(wait=True)
     assert len(executor._task_queue) == 0

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from AnyQt.QtCore import QObject
 from ewokscore import Task
@@ -77,7 +78,8 @@ def test_threaded_task_executor_queue(qtapp):
     assert obj.results == {"result": 3}
 
 
-def test_cancel_current_task_in_task_executor_queue(qtapp):
+@pytest.mark.parametrize("cancellation_api", ("executor", "future"))
+def test_cancel_current_task_in_task_executor_queue(qtapp, cancellation_api):
     """test an 'infinite' task that we want to kill and launch another task behind"""
 
     class MyObject(QObject):
@@ -152,24 +154,27 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
     obj4 = MyObject()
     obj5 = MyObject()
 
-    obj4_id = executor.add(
+    obj4_future = executor.add(
         inputs={
             "duration": 2,
         },
         _callbacks=(obj4.finished_callback,),
     )
-    obj5_id = executor.add(
+    executor.add(
         inputs={
             "duration": 2,
         },
         _callbacks=(obj5.finished_callback,),
     )
-    executor.cancel_task(task_exec_id=obj5_id)
+    if cancellation_api == "future":
+        assert obj4.cancel(), "future cancellation failed"
+    elif cancellation_api == "executor":
+        executor.cancel_task(task_exec_id=obj4_future.task_exec_id)
 
     len(executor._task_queue) == 1
     remaining_task_exec_ids = list(executor._task_exec_ids.keys()) + [
         executor._current_task_exec_id,
     ]
-    assert obj4_id in remaining_task_exec_ids
+    assert obj4_future in remaining_task_exec_ids
     executor.cancel_all_tasks(wait=True)
     assert len(executor._task_queue) == 0

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -85,8 +85,7 @@ def test_threaded_task_executor_queue(qtapp):
     assert future.result() == obj.results
 
 
-@pytest.mark.parametrize("cancellation_api", ("executor", "future"))
-def test_cancel_current_task_in_task_executor_queue(qtapp, cancellation_api):
+def test_cancel_current_task_in_task_executor_queue(qtapp):
     """test an 'infinite' task that we want to kill and launch another task behind"""
 
     class MyObject(QObject):
@@ -168,21 +167,19 @@ def test_cancel_current_task_in_task_executor_queue(qtapp, cancellation_api):
         },
         _callbacks=(obj4.finished_callback,),
     )
-    executor.add(
+    obj5_future = executor.add(
         inputs={
             "duration": 2,
         },
         _callbacks=(obj5.finished_callback,),
     )
-    if cancellation_api == "future":
-        assert obj4.cancel(), "future cancellation failed"
-    elif cancellation_api == "executor":
-        executor.cancel_task(task_exec_id=obj4_future.task_exec_id)
+    assert obj4_future.running()
+    assert obj4_future.cancel(), "future cancellation failed"
 
     len(executor._task_queue) == 1
-    remaining_task_exec_ids = list(executor._task_exec_ids.keys()) + [
-        executor._current_task_exec_id,
+    remaining_futures = list(executor._task_futures.keys()) + [
+        executor._current_task_future,
     ]
-    assert obj4_future in remaining_task_exec_ids
+    assert obj5_future in remaining_futures
     executor.cancel_all_tasks(wait=True)
     assert len(executor._task_queue) == 0

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -1,12 +1,13 @@
 import time
-import pytest
 
+import pytest
 from AnyQt.QtCore import QObject
 from ewokscore import Task
 from ewokscore.missing_data import MISSING_DATA
 from ewokscore.tests.examples.tasks.sumtask import SumTask
 
-from ..gui.concurrency.base import TaskExecutor, TaskExecutionID
+from ..gui.concurrency.base import TaskExecutionID
+from ..gui.concurrency.base import TaskExecutor
 from ..gui.concurrency.queued import TaskExecutorQueue
 from ..gui.concurrency.threaded import ThreadedTaskExecutor
 from ..gui.qt_utils.app import QtEvent
@@ -17,19 +18,24 @@ def test_task_executor():
     assert not executor.has_task
     assert not executor.succeeded
 
-    executor.create_task(inputs={"a": 1, "b": 2})
+    executor.create_task(inputs={"a": 1, "b": 2, "delay": 0.5})
     assert executor.has_task
     assert not executor.succeeded
 
-    task_exec_id = executor.execute_task()
-    assert task_exec_id not in ("", None) and isinstance(task_exec_id, TaskExecutionID)
+    future_task = executor.execute_task()
+    assert future_task.task_exec_id not in ("", None) and isinstance(
+        future_task.task_exec_id, TaskExecutionID
+    )
     assert executor.succeeded
     results = {k: v.value for k, v in executor.output_variables.items()}
     assert results == {"result": 3}
+    assert future_task.result(timeout=1) == results
+    assert future_task.exception() is None
 
     # dummy test of the API
-    executor.cancel_task(task_exec_id=task_exec_id)
+    executor.cancel_task(task_exec_id=future_task.task_exec_id)
     executor.cancel_all_tasks()
+    assert future_task.cancel() is False
 
 
 def test_threaded_task_executor(qtapp):
@@ -73,9 +79,10 @@ def test_threaded_task_executor_queue(qtapp):
 
     obj = MyObject()
     executor = TaskExecutorQueue(ewokstaskclass=SumTask)
-    executor.add(inputs={"a": 1, "b": 2}, _callbacks=(obj.finished_callback,))
+    future = executor.add(inputs={"a": 1, "b": 2}, _callbacks=(obj.finished_callback,))
     assert obj.finished.wait(timeout=3)
     assert obj.results == {"result": 3}
+    assert future.result() == obj.results
 
 
 @pytest.mark.parametrize("cancellation_api", ("executor", "future"))
@@ -88,6 +95,7 @@ def test_cancel_current_task_in_task_executor_queue(qtapp, cancellation_api):
         """
 
         def __init__(self):
+            super().__init__()
             self.results = None
             self.finished = QtEvent()
 
@@ -132,7 +140,7 @@ def test_cancel_current_task_in_task_executor_queue(qtapp, cancellation_api):
     )
     assert not executor.is_available
     # cancel obj 1
-    executor.cancel_running_task(wait=False)
+    executor._cancel_running_task(wait=False)
     assert obj2.finished.wait(timeout=30)
     assert obj1.results["result"] is MISSING_DATA
     assert executor.is_available

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -27,7 +27,7 @@ def test_task_executor():
     assert results == {"result": 3}
 
     # dummy test of the API
-    executor.cancel_task(task_id=task_exec_id)
+    executor.cancel_task(task_exec_id=task_exec_id)
     executor.cancel_all_tasks()
 
 
@@ -164,12 +164,12 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
         },
         _callbacks=(obj5.finished_callback,),
     )
-    assert executor.cancel_task(task_id=obj5_id)
+    assert executor.cancel_task(task_exec_id=obj5_id)
 
     assert len(executor) == 1
-    remaining_task_ids = list(executor._task_ids.keys()) + [
-        executor._current_task_id,
+    remaining_task_exec_ids = list(executor._task_exec_ids.keys()) + [
+        executor._current_task_exec_id,
     ]
-    assert obj4_id in remaining_task_ids
+    assert obj4_id in remaining_task_exec_ids
     executor.cancel_all_tasks(wait=True)
     assert len(executor) == 0

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -164,12 +164,12 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
         },
         _callbacks=(obj5.finished_callback,),
     )
-    assert executor.cancel_task(task_exec_id=obj5_id)
+    executor.cancel_task(task_exec_id=obj5_id)
 
-    assert len(executor) == 1
+    len(executor._task_queue) == 1
     remaining_task_exec_ids = list(executor._task_exec_ids.keys()) + [
         executor._current_task_exec_id,
     ]
     assert obj4_id in remaining_task_exec_ids
     executor.cancel_all_tasks(wait=True)
-    assert len(executor) == 0
+    assert len(executor._task_queue) == 0

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -142,3 +142,29 @@ def test_cancel_current_task_in_task_executor_queue(qtapp):
     assert obj3.results["result"] == "have waited 0.2s"
 
     assert executor.is_available
+
+    # test cancelling any task in the queue (even if not running)
+    obj4 = MyObject()
+    obj5 = MyObject()
+
+    obj4_id = executor.add(
+        inputs={
+            "duration": 2,
+        },
+        _callbacks=(obj4.finished_callback,),
+    )
+    obj5_id = executor.add(
+        inputs={
+            "duration": 2,
+        },
+        _callbacks=(obj5.finished_callback,),
+    )
+    assert executor.cancel_task(task_id=obj5_id)
+
+    assert len(executor) == 1
+    remaining_task_ids = list(executor._task_ids.keys()) + [
+        executor._current_task_id,
+    ]
+    assert obj4_id in remaining_task_ids
+    executor.cancel_all_tasks(wait=True)
+    assert len(executor) == 0

--- a/src/ewoksorange/tests/test_task_executor.py
+++ b/src/ewoksorange/tests/test_task_executor.py
@@ -9,6 +9,7 @@ from ewokscore.tests.examples.tasks.sumtask import SumTask
 from ..gui.concurrency.base import TaskExecutionID
 from ..gui.concurrency.base import TaskExecutor
 from ..gui.concurrency.queued import TaskExecutorQueue
+from ..gui.concurrency.threaded import MultiThreadedTaskExecutor
 from ..gui.concurrency.threaded import ThreadedTaskExecutor
 from ..gui.qt_utils.app import QtEvent
 
@@ -60,6 +61,32 @@ def test_threaded_task_executor(qtapp):
     assert results == {"result": 3}
 
     executor.finished.disconnect(finished_callback)
+
+
+def test_multi_threaded_task_executor(qtapp):
+    class MyObject(QObject):
+        def __init__(self):
+            self.results = None
+            self.finished = QtEvent()
+
+        def finished_callback(self, task_executor, future):
+            self.results = {
+                k: v.value for k, v in task_executor.output_variables.items()
+            }
+            assert future.result() == self.results
+            self.finished.set()
+
+    obj = MyObject()
+    executor = MultiThreadedTaskExecutor(ewokstaskclass=SumTask)
+    executor.create_task(
+        inputs={"a": 1, "b": 2},
+        _callbacks=(obj.finished_callback,),
+    )
+    future = executor.execute_task()
+
+    assert obj.finished.wait(timeout=3)
+    assert obj.results == {"result": 3}
+    assert future.result() == obj.results
 
 
 def test_threaded_task_executor_queue(qtapp):

--- a/src/ewoksorange/tests/utils.py
+++ b/src/ewoksorange/tests/utils.py
@@ -1,3 +1,4 @@
+from time import sleep
 from typing import Mapping
 from typing import Optional
 from typing import Type
@@ -32,3 +33,30 @@ def execute_task(
         task.execute()
         return task.get_output_values()
     raise TypeError("task")
+
+
+class DummyTask(
+    Task,
+    input_names=("my_object", "value"),
+    optional_input_names=("sleep_duration",),
+    output_names=("my_object",),
+):
+    """Task that set a value to MyObject and set a 'finished' Event"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__cancelled = False
+
+    def run(self):
+        sleep(self.get_input_values().get("sleep_duration", 0))
+        my_object = self.inputs.my_object
+
+        if self.__cancelled:
+            my_object.value = "cancelled"
+        else:
+            my_object.value = self.inputs.value
+        self.outputs.my_object = my_object
+        my_object.finished_callback()
+
+    def cancel(self):
+        self.__cancelled = True


### PR DESCRIPTION
# Overview

This PR adds a complete API to handle task cancellation from the different ewoksorange widgets.

The idea is to make to:

* provide a Future (under the form of a `TaskFuture`) to the user when a task is executed.
* This future can be cancelled by the user (either if processing is pending or on-going)
* Adapt existing structures to be able to cancel a specific task and all existing tasks of an executor
* The public API for task cancellation is moved from the different executors to the  ̀Future` object. Only remains for conveniance a `cancel_all_tasks` Moving `cancel_running_task` also ease handling correctly of the `Future.cancel ̀. Because `cancel` must call executor cancellation **and** executor cancellation must make sure `Future.cancel` is called to have a coherent state. This was we only need to handle task cancellation is called ... from the `Future`.