### PR TITLE
fix[ParameterForm]: `QDialog.exec_` is not available in Qt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed 
+
+- Fix `ParameterForm` file system selection in QT6 (Replace `QDialog.exec_` with `QDialog.exec`).
+
 ## [5.0.1] - 2026-04-17
 
 ### Fixed

--- a/src/ewoksorange/gui/widgets/parameter_form.py
+++ b/src/ewoksorange/gui/widgets/parameter_form.py
@@ -596,7 +596,7 @@ class ParameterForm(QtWidgets.QWidget):
         if filename:
             dialog.setDirectory(os.path.dirname(filename))
 
-        if not dialog.exec_():
+        if not dialog.exec():
             dialog.close()
             return
 
@@ -679,7 +679,7 @@ class ParameterForm(QtWidgets.QWidget):
         if directory:
             dialog.setDirectory(directory)
 
-        if not dialog.exec_():
+        if not dialog.exec():
             dialog.close()
             return
 


### PR DESCRIPTION
Fix exception in Qt6 : `QDialog.exec_` method does not exist