### PR TITLE
qt_message_handler: fix access to 'QtMsgType' Enum value.

### DIFF
--- a/src/ewoksorange/gui/qt_utils/app.py
+++ b/src/ewoksorange/gui/qt_utils/app.py
@@ -154,13 +154,13 @@ def get_all_qtwidgets() -> list:
 
 
 def qt_message_handler(level, context, message) -> None:
-    if level == QtCore.QtInfoMsg:
+    if level == QtCore.QtMsgType.QtInfoMsg:
         log = logger.info
-    elif level == QtCore.QtWarningMsg:
+    elif level == QtCore.QtMsgType.QtWarningMsg:
         log = logger.warning
-    elif level == QtCore.QtCriticalMsg:
+    elif level == QtCore.QtMsgType.QtCriticalMsg:
         log = logger.error
-    elif level == QtCore.QtFatalMsg:
+    elif level == QtCore.QtMsgType.QtFatalMsg:
         log = logger.fatal
     else:
         log = logger.debug


### PR DESCRIPTION
Access to the different `QtMsgType` used to be possible directly from 'QtCore'. It has been fixed on PySide6 and PyQt6.

<img width="1496" height="986" alt="image" src="https://github.com/user-attachments/assets/f46215ee-2763-41a4-8a20-cea56aaf6ba5" />
Checked also in Pyside2 but is was a pain. Had segfault with recent version of python... works with 3.10 at least

------------ 
<img width="641" height="302" alt="image" src="https://github.com/user-attachments/assets/cfc6a310-c935-405c-a2e1-7d3122148cbe" />

------------ 
Note: needs to be ported to 4.1.0 and do a bug fix release