### PR TITLE
Store all graph attributes in OWS format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `ParameterForm` file system selection in QT6 (Replace `QDialog.exec_` with `QDialog.exec`).
+- Store all graph attributes in OWS format.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "backports.strenum;python_version < '3.11'",
     "packaging",
     "silx[full_no_qt]",
+    "defusedxml",
 ]
 
 [project.urls]

--- a/src/ewoksorange/gui/_patch_on_import.py
+++ b/src/ewoksorange/gui/_patch_on_import.py
@@ -2,7 +2,11 @@ from ._oasys_patch import oasys_patch
 from .orange_utils.signal_manager import patch_signal_manager
 from .owwidgets.summarizers import summarize  # noqa: F401
 from .workflows.owscheme import patch_parse_ows_stream
+from .workflows.owscheme import patch_scheme_load
+from .workflows.owscheme import patch_scheme_to_etree
 
 oasys_patch()
 patch_parse_ows_stream()
+patch_scheme_load()
+patch_scheme_to_etree()
 patch_signal_manager()

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -14,6 +14,8 @@ from typing import Union
 from uuid import uuid4
 from xml.etree import ElementTree
 
+from defusedxml.ElementTree import parse as xml_fromstring
+from defusedxml.ElementTree import parse as xml_parse
 from ewokscore import load_graph
 from ewokscore.graph import TaskGraph
 from ewokscore.graph.serialize import GraphRepresentation
@@ -499,18 +501,18 @@ def _read_ewoks_graph_attrs(source: Union[str, IO]) -> Optional[dict]:
     """Extract ewoks graph attributes from the dedicated XML element, if present."""
     try:
         if isinstance(source, str):
-            tree = ElementTree.parse(source)
+            tree = xml_parse(source)
             root = tree.getroot()
         else:
             pos = source.tell() if hasattr(source, "tell") else None
-            root = ElementTree.fromstring(source.read())
+            root = xml_fromstring(source.read())
             if pos is not None:
                 source.seek(pos)
         elem = root.find(_EWOKS_GRAPH_ATTRS_TAG)
         if elem is not None and elem.text:
             return json.loads(elem.text)
     except Exception:
-        pass
+        logger.debug("Failed to read ewoks graph attributes", exc_info=True)
     return None
 
 

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -14,7 +14,6 @@ from typing import Union
 from uuid import uuid4
 from xml.etree import ElementTree
 
-from defusedxml.ElementTree import parse as xml_fromstring
 from defusedxml.ElementTree import parse as xml_parse
 from ewokscore import load_graph
 from ewokscore.graph import TaskGraph
@@ -499,20 +498,19 @@ _EWOKS_GRAPH_ATTRS_TAG = "ewoks_graph_attrs"
 
 def _read_ewoks_graph_attrs(source: Union[str, IO]) -> Optional[dict]:
     """Extract ewoks graph attributes from the dedicated XML element, if present."""
+    pos = None
     try:
-        if isinstance(source, str):
-            tree = xml_parse(source)
-            root = tree.getroot()
-        else:
-            pos = source.tell() if hasattr(source, "tell") else None
-            root = xml_fromstring(source.read())
-            if pos is not None:
-                source.seek(pos)
+        if not isinstance(source, str) and hasattr(source, "tell"):
+            pos = source.tell()
+        root = xml_parse(source).getroot()
         elem = root.find(_EWOKS_GRAPH_ATTRS_TAG)
         if elem is not None and elem.text:
             return json.loads(elem.text)
     except Exception:
         logger.debug("Failed to read ewoks graph attributes", exc_info=True)
+    finally:
+        if pos is not None and not isinstance(source, str):
+            source.seek(pos)
     return None
 
 

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -135,11 +135,17 @@ def ows_to_ewoks(
     ows = read_ows(source)
 
     description = ows.description
+
     try:
         ewoksinfo = json.loads(description)
-        description = ewoksinfo["description"]
     except Exception:
-        ewoksinfo = dict()
+        ewoksinfo = {}
+
+    if isinstance(ewoksinfo, dict):
+        description = ewoksinfo.pop("description", description)
+    else:
+        ewoksinfo = {}
+
     if not description and isinstance(source, str):
         description = (
             "Ewoks workflow '%s'" % os.path.splitext(os.path.basename(source))[0]
@@ -214,6 +220,7 @@ def ows_to_ewoks(
     graph_attrs = dict()
     graph_attrs["id"] = title
     graph_attrs["label"] = description
+    graph_attrs.update(ewoksinfo)
     if ows.annotations:
         graph_attrs["ows"] = {
             "annotations": [
@@ -347,10 +354,16 @@ class OwsSchemeWrapper:
         if isinstance(graph, TaskGraph):
             graph = graph.dump()
 
-        self.title = graph["graph"].get("id", "")
-        self._description = graph["graph"].get("label", "")
+        graph_attrs = graph.get("graph", {})
 
-        ows = graph["graph"].get("ows", dict())
+        self.title = graph_attrs.get("id", "")
+        self._description = graph_attrs.get("label", "")
+
+        self._ewoks_graph_attrs = {
+            k: v for k, v in graph_attrs.items() if k not in ("id", "label", "ows")
+        }
+
+        ows = graph_attrs.get("ows", dict())
         self._annotations = [
             _deserialize_annotation(annotation)
             for annotation in ows.get("annotations", list())
@@ -414,14 +427,16 @@ class OwsSchemeWrapper:
 
     @property
     def description(self):
+        info = dict(self._ewoks_graph_attrs)
+
         if self.missing_links:
-            description = {
-                "description": self._description,
-                "missing_links": self.missing_links,
-            }
-            return json.dumps(description)
-        else:
-            return self._description
+            info["missing_links"] = self.missing_links
+
+        if info:
+            info["description"] = self._description
+            return json.dumps(info)
+
+        return self._description
 
     def _convert_link(self, link):
         """In Orange, a link must transfer data"""

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -12,6 +12,7 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 from uuid import uuid4
+from xml.etree import ElementTree
 
 from ewokscore import load_graph
 from ewokscore.graph import TaskGraph
@@ -133,18 +134,20 @@ def ows_to_ewoks(
 ) -> TaskGraph:
     """Load an Orange Workflow Scheme from a file or stream and convert it to a `TaskGraph`."""
     ows = read_ows(source)
+    ewoksinfo = _read_ewoks_graph_attrs(source)
 
     description = ows.description
 
-    try:
-        ewoksinfo = json.loads(description)
-    except Exception:
-        ewoksinfo = {}
-
-    if isinstance(ewoksinfo, dict):
-        description = ewoksinfo.pop("description", description)
-    else:
-        ewoksinfo = {}
+    if ewoksinfo is None:
+        # backward compatibility: extra attrs were stored as JSON in the description
+        try:
+            ewoksinfo = json.loads(description)
+        except Exception:
+            ewoksinfo = {}
+        if isinstance(ewoksinfo, dict):
+            description = ewoksinfo.pop("description", description)
+        else:
+            ewoksinfo = {}
 
     if not description and isinstance(source, str):
         description = (
@@ -412,6 +415,8 @@ class OwsSchemeWrapper:
                     f"Orange workflows only support task of types 'class' or 'generated'. Got {task_type!r}"
                 )
 
+        self._runtime_env = dict()
+
         self.links = list()
         self.missing_links = list()
         for link in graph["links"]:
@@ -427,16 +432,21 @@ class OwsSchemeWrapper:
 
     @property
     def description(self):
-        info = dict(self._ewoks_graph_attrs)
+        return self._description
 
+    @property
+    def ewoks_graph_attrs(self) -> Optional[dict]:
+        """Extra ewoks graph attributes beyond id/label/ows, plus missing_links."""
+        info = dict(self._ewoks_graph_attrs)
         if self.missing_links:
             info["missing_links"] = self.missing_links
+        return info if info else None
 
-        if info:
-            info["description"] = self._description
-            return json.dumps(info)
+    def get_runtime_env(self, key, default=None):
+        return self._runtime_env.get(key, default)
 
-        return self._description
+    def set_runtime_env(self, key, value):
+        self._runtime_env[key] = value
 
     def _convert_link(self, link):
         """In Orange, a link must transfer data"""
@@ -482,6 +492,28 @@ class OwsSchemeWrapper:
         return list()
 
 
+_EWOKS_GRAPH_ATTRS_TAG = "ewoks_graph_attrs"
+
+
+def _read_ewoks_graph_attrs(source: Union[str, IO]) -> Optional[dict]:
+    """Extract ewoks graph attributes from the dedicated XML element, if present."""
+    try:
+        if isinstance(source, str):
+            tree = ElementTree.parse(source)
+            root = tree.getroot()
+        else:
+            pos = source.tell() if hasattr(source, "tell") else None
+            root = ElementTree.fromstring(source.read())
+            if pos is not None:
+                source.seek(pos)
+        elem = root.find(_EWOKS_GRAPH_ATTRS_TAG)
+        if elem is not None and elem.text:
+            return json.loads(elem.text)
+    except Exception:
+        pass
+    return None
+
+
 def read_ows(source: Union[str, IO]) -> ReadSchemeType:
     """Read an Orange Workflow Scheme from a file or a stream."""
     return _original_parse_ows_stream(source)
@@ -496,9 +528,14 @@ def write_ows(scheme: OwsSchemeWrapper, destination: Union[str, IO]):
     tree = readwrite.scheme_to_etree(
         scheme, data_format="literal", pickle_fallback=True
     )
-    for node in tree.getroot().find("nodes"):
+    root = tree.getroot()
+    for node in root.find("nodes"):
         del node.attrib["scheme_node_type"]
-    readwrite.indent(tree.getroot(), 0)
+    ewoks_attrs = scheme.ewoks_graph_attrs
+    if ewoks_attrs is not None:
+        elem = ElementTree.SubElement(root, _EWOKS_GRAPH_ATTRS_TAG)
+        elem.text = json.dumps(ewoks_attrs)
+    readwrite.indent(root, 0)
     if isinstance(destination, str) and os.path.dirname(destination):
         os.makedirs(os.path.dirname(destination), exist_ok=True)
     tree.write(destination, encoding="utf-8", xml_declaration=True)
@@ -548,3 +585,39 @@ def _patched_parse_ows_stream(*args, **kwargs) -> ReadSchemeType:
 
 def patch_parse_ows_stream():
     readwrite.parse_ows_stream = _patched_parse_ows_stream
+
+
+_original_scheme_load = readwrite.scheme_load
+_original_scheme_to_etree = readwrite.scheme_to_etree
+
+
+def _patched_scheme_load(scheme, stream, *args, **kwargs):
+    """Preserve `_EWOKS_GRAPH_ATTRS_TAG` across a live canvas edit/save
+    round-trip.
+    """
+    ewoks_attrs = _read_ewoks_graph_attrs(stream)
+    scheme = _original_scheme_load(scheme, stream, *args, **kwargs)
+    if ewoks_attrs is not None:
+        scheme.set_runtime_env(_EWOKS_GRAPH_ATTRS_TAG, ewoks_attrs)
+    return scheme
+
+
+def _patched_scheme_to_etree(scheme, *args, **kwargs):
+    """Counterpart of `_patched_scheme_load`: re-attach the ewoks graph attrs
+    (if any were stashed in the scheme's runtime environment)
+    """
+    tree = _original_scheme_to_etree(scheme, *args, **kwargs)
+    ewoks_attrs = scheme.get_runtime_env(_EWOKS_GRAPH_ATTRS_TAG)
+    print("ewoks_attrs are", ewoks_attrs)
+    if ewoks_attrs is not None:
+        elem = ElementTree.SubElement(tree.getroot(), _EWOKS_GRAPH_ATTRS_TAG)
+        elem.text = json.dumps(ewoks_attrs)
+    return tree
+
+
+def patch_scheme_to_etree():
+    readwrite.scheme_to_etree = _patched_scheme_to_etree
+
+
+def patch_scheme_load():
+    readwrite.scheme_load = _patched_scheme_load

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -610,7 +610,6 @@ def _patched_scheme_to_etree(scheme, *args, **kwargs):
     """
     tree = _original_scheme_to_etree(scheme, *args, **kwargs)
     ewoks_attrs = scheme.get_runtime_env(_EWOKS_GRAPH_ATTRS_TAG)
-    print("ewoks_attrs are", ewoks_attrs)
     if ewoks_attrs is not None:
         elem = ElementTree.SubElement(tree.getroot(), _EWOKS_GRAPH_ATTRS_TAG)
         elem.text = json.dumps(ewoks_attrs)

--- a/src/ewoksorange/tests/test_ows_conversion.py
+++ b/src/ewoksorange/tests/test_ows_conversion.py
@@ -8,6 +8,7 @@ from ewokscore import load_graph
 from ewokscore.tests.examples.graphs import get_graph
 from ewokscore.tests.examples.graphs import graph_names
 
+from ..gui.workflows.owscheme import _read_ewoks_graph_attrs
 from ..gui.workflows.owscheme import ewoks_to_ows
 from ..gui.workflows.owscheme import graph_is_supported
 from ..gui.workflows.owscheme import ows_to_ewoks
@@ -61,3 +62,31 @@ def test_ewoks_to_ows(graph_name, tmpdir):
         destination, title_as_node_id=True, preserve_ows_info=False
     )
     assert ewoksgraph == ewoksgraph2
+
+
+def test_read_ewoks_graph_attrs_from_path_and_stream(tmp_path):
+    content = (
+        b'<?xml version="1.0" ?>'
+        b"<scheme>"
+        b'<ewoks_graph_attrs>{"foo": "bar"}</ewoks_graph_attrs>'
+        b"</scheme>"
+    )
+    filename = tmp_path / "test.ows"
+    filename.write_bytes(content)
+
+    assert _read_ewoks_graph_attrs(str(filename)) == {"foo": "bar"}
+
+    with open(filename, "rb") as stream:
+        assert _read_ewoks_graph_attrs(stream) == {"foo": "bar"}
+        assert stream.tell() == 0  # stream position must be preserved
+
+
+def test_read_ewoks_graph_attrs_restores_stream_position_on_failure(tmp_path):
+    filename = tmp_path / "invalid.ows"
+    filename.write_bytes(b"not xml")
+
+    assert _read_ewoks_graph_attrs(str(filename)) is None
+
+    with open(filename, "rb") as stream:
+        assert _read_ewoks_graph_attrs(stream) is None
+        assert stream.tell() == 0

--- a/src/ewoksorange/tests/test_owwidget_parallel.py
+++ b/src/ewoksorange/tests/test_owwidget_parallel.py
@@ -72,7 +72,7 @@ def test_owwidget_parallel(qtapp):
     # cancel some jobs
     for future, cancel in zip(futures, cancels):
         if cancel:
-            assert future.abort(), "Future cannot be aborted."
+            _ = future.abort()
 
     # check results
     times = []
@@ -81,12 +81,17 @@ def test_owwidget_parallel(qtapp):
             with pytest.raises(TaskExecutionError) as exc_info:
                 _ = future.result(timeout=10)
 
+            assert future.aborted()
+
             assert isinstance(exc_info.value.__cause__, Cancelled)
             assert exc_info.value.__cause__.value == value
 
             times.append(exc_info.value.__cause__.time)
         else:
             outputs = future.result(timeout=10)
+
+            assert not future.aborted()
+
             assert outputs["value"].value == value
             times.append(outputs["time"].value)
 


### PR DESCRIPTION
Example:

```bash
ewoks convert demo demo.ows --test  # add more graph attributes
ewoks execute demo.ows --engine orange
```

The workflow description is the place we abuse to store Ewoks graph attributes

<img width="1517" height="891" alt="image" src="https://github.com/user-attachments/assets/7f2f3f97-fefc-47c8-a42f-1fc6d9d122f7" />