### PR TITLE
owscheme: store ewoks graph attributes into a dedicated new node.

### DIFF
--- a/src/ewoksorange/gui/_patch_on_import.py
+++ b/src/ewoksorange/gui/_patch_on_import.py
@@ -2,7 +2,11 @@ from ._oasys_patch import oasys_patch
 from .orange_utils.signal_manager import patch_signal_manager
 from .owwidgets.summarizers import summarize  # noqa: F401
 from .workflows.owscheme import patch_parse_ows_stream
+from .workflows.owscheme import patch_scheme_load
+from .workflows.owscheme import patch_scheme_to_etree
 
 oasys_patch()
 patch_parse_ows_stream()
+patch_scheme_load()
+patch_scheme_to_etree()
 patch_signal_manager()

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -12,6 +12,7 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 from uuid import uuid4
+from xml.etree import ElementTree
 
 from ewokscore import load_graph
 from ewokscore.graph import TaskGraph
@@ -133,18 +134,20 @@ def ows_to_ewoks(
 ) -> TaskGraph:
     """Load an Orange Workflow Scheme from a file or stream and convert it to a `TaskGraph`."""
     ows = read_ows(source)
+    ewoksinfo = _read_ewoks_graph_attrs(source)
 
     description = ows.description
 
-    try:
-        ewoksinfo = json.loads(description)
-    except Exception:
-        ewoksinfo = {}
-
-    if isinstance(ewoksinfo, dict):
-        description = ewoksinfo.pop("description", description)
-    else:
-        ewoksinfo = {}
+    if ewoksinfo is None:
+        # backward compatibility: extra attrs were stored as JSON in the description
+        try:
+            ewoksinfo = json.loads(description)
+        except Exception:
+            ewoksinfo = {}
+        if isinstance(ewoksinfo, dict):
+            description = ewoksinfo.pop("description", description)
+        else:
+            ewoksinfo = {}
 
     if not description and isinstance(source, str):
         description = (
@@ -427,16 +430,15 @@ class OwsSchemeWrapper:
 
     @property
     def description(self):
-        info = dict(self._ewoks_graph_attrs)
+        return self._description
 
+    @property
+    def ewoks_graph_attrs(self) -> Optional[dict]:
+        """Extra ewoks graph attributes beyond id/label/ows, plus missing_links."""
+        info = dict(self._ewoks_graph_attrs)
         if self.missing_links:
             info["missing_links"] = self.missing_links
-
-        if info:
-            info["description"] = self._description
-            return json.dumps(info)
-
-        return self._description
+        return info if info else None
 
     def _convert_link(self, link):
         """In Orange, a link must transfer data"""
@@ -482,6 +484,28 @@ class OwsSchemeWrapper:
         return list()
 
 
+_EWOKS_GRAPH_ATTRS_TAG = "ewoks_graph_attrs"
+
+
+def _read_ewoks_graph_attrs(source: Union[str, IO]) -> Optional[dict]:
+    """Extract ewoks graph attributes from the dedicated XML element, if present."""
+    try:
+        if isinstance(source, str):
+            tree = ElementTree.parse(source)
+            root = tree.getroot()
+        else:
+            pos = source.tell() if hasattr(source, "tell") else None
+            root = ElementTree.fromstring(source.read())
+            if pos is not None:
+                source.seek(pos)
+        elem = root.find(_EWOKS_GRAPH_ATTRS_TAG)
+        if elem is not None and elem.text:
+            return json.loads(elem.text)
+    except Exception:
+        pass
+    return None
+
+
 def read_ows(source: Union[str, IO]) -> ReadSchemeType:
     """Read an Orange Workflow Scheme from a file or a stream."""
     return _original_parse_ows_stream(source)
@@ -496,9 +520,14 @@ def write_ows(scheme: OwsSchemeWrapper, destination: Union[str, IO]):
     tree = readwrite.scheme_to_etree(
         scheme, data_format="literal", pickle_fallback=True
     )
-    for node in tree.getroot().find("nodes"):
+    root = tree.getroot()
+    for node in root.find("nodes"):
         del node.attrib["scheme_node_type"]
-    readwrite.indent(tree.getroot(), 0)
+    ewoks_attrs = scheme.ewoks_graph_attrs
+    if ewoks_attrs is not None:
+        elem = ElementTree.SubElement(root, _EWOKS_GRAPH_ATTRS_TAG)
+        elem.text = json.dumps(ewoks_attrs)
+    readwrite.indent(root, 0)
     if isinstance(destination, str) and os.path.dirname(destination):
         os.makedirs(os.path.dirname(destination), exist_ok=True)
     tree.write(destination, encoding="utf-8", xml_declaration=True)

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -577,3 +577,39 @@ def _patched_parse_ows_stream(*args, **kwargs) -> ReadSchemeType:
 
 def patch_parse_ows_stream():
     readwrite.parse_ows_stream = _patched_parse_ows_stream
+
+
+_original_scheme_load = readwrite.scheme_load
+_original_scheme_to_etree = readwrite.scheme_to_etree
+
+
+def _patched_scheme_load(scheme, stream, *args, **kwargs):
+    """Preserve `_EWOKS_GRAPH_ATTRS_TAG` across a live canvas edit/save
+    round-trip.
+    """
+    ewoks_attrs = _read_ewoks_graph_attrs(stream)
+    scheme = _original_scheme_load(scheme, stream, *args, **kwargs)
+    if ewoks_attrs is not None:
+        scheme.set_runtime_env(_EWOKS_GRAPH_ATTRS_TAG, ewoks_attrs)
+    return scheme
+
+
+def _patched_scheme_to_etree(scheme, *args, **kwargs):
+    """Counterpart of `_patched_scheme_load`: re-attach the ewoks graph attrs
+    (if any were stashed in the scheme's runtime environment)
+    """
+    tree = _original_scheme_to_etree(scheme, *args, **kwargs)
+    ewoks_attrs = scheme.get_runtime_env(_EWOKS_GRAPH_ATTRS_TAG)
+    print("ewoks_attrs are", ewoks_attrs)
+    if ewoks_attrs is not None:
+        elem = ElementTree.SubElement(tree.getroot(), _EWOKS_GRAPH_ATTRS_TAG)
+        elem.text = json.dumps(ewoks_attrs)
+    return tree
+
+
+def patch_scheme_to_etree():
+    readwrite.scheme_to_etree = _patched_scheme_to_etree
+
+
+def patch_scheme_load():
+    readwrite.scheme_load = _patched_scheme_load

--- a/src/ewoksorange/gui/workflows/owscheme.py
+++ b/src/ewoksorange/gui/workflows/owscheme.py
@@ -415,6 +415,8 @@ class OwsSchemeWrapper:
                     f"Orange workflows only support task of types 'class' or 'generated'. Got {task_type!r}"
                 )
 
+        self._runtime_env = dict()
+
         self.links = list()
         self.missing_links = list()
         for link in graph["links"]:
@@ -439,6 +441,12 @@ class OwsSchemeWrapper:
         if self.missing_links:
             info["missing_links"] = self.missing_links
         return info if info else None
+
+    def get_runtime_env(self, key, default=None):
+        return self._runtime_env.get(key, default)
+
+    def set_runtime_env(self, key, value):
+        self._runtime_env[key] = value
 
     def _convert_link(self, link):
         """In Orange, a link must transfer data"""


### PR DESCRIPTION
Move storing ewoks graph attributes from 'description' to a dedicated node.

This is a quick "show case" done by AI. It can be rework if needed. But I don't think we are loosing feature by using a new dedicated node. It will be ignored by orange if we use `orange-canvas` but I think this is the behavior we want.

[demo.ows](https://github.com/user-attachments/files/30533954/demo.xml) result with this PR.
note: demo.ows has been renamed demo.xml to be able to attach the file.