### PR TITLE
_OWEwoksExecutorWidget: call progressBarFinished() after propagate_downstream()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `OrangeCanvasHandler.wait_widgets`: fix a race where a widget executing on a
+  background thread could briefly look "settled" (task finished, not active)
+  before its outputs were actually propagated downstream, by making
+  `OWEwoksBaseWidget` call `propagate_downstream` before `progressBarFinished`.
+
 ## [6.0.0rc2] - 2026-08-02
 
 ### Fixed

--- a/doc/explanations.rst
+++ b/doc/explanations.rst
@@ -1,0 +1,7 @@
+Explanations
+============
+
+.. toctree::
+    :maxdepth: 1
+
+    explanations/execution

--- a/doc/explanations/execution.rst
+++ b/doc/explanations/execution.rst
@@ -1,0 +1,146 @@
+Execution Lifecycle
+====================
+
+This page explains how a workflow actually runs on the Orange canvas: how the
+:class:`SignalManager <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme>`
+schedules node updates, how an Ewoks-Orange widget executes its task, and how
+outputs propagate to downstream widgets. Native Orange widgets (``OWWidget``)
+and Ewoks widgets (:class:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget`)
+share the same scheduling machinery; only the "how does *this* widget execute
+its work" step differs.
+
+Key players
+-----------
+
+- **SignalManager** (``orangecanvas``/``orangewidget``): owns the queue of
+  signals to deliver and a single coalescing 100 ms timer that drives
+  delivery. It never executes widget code itself; it only calls
+  :meth:`handleNewSignals() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.handleNewSignals>`
+  once all of a node's inputs have been updated.
+- **OWEwoksBaseWidget** (:class:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget`,
+  ``ewoksorange``): implements ``handleNewSignals()`` by executing the bound
+  Ewoks task and, once done, propagating outputs (or invalidation, on
+  failure) through
+  :meth:`propagate_downstream() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.propagate_downstream>`.
+- **EwoksExecutor** (:class:`~ewoksorange.gui.concurrency.executor.EwoksExecutor`,
+  ``ewoksorange``): receives submitted tasks
+  (:meth:`submit_task() <ewoksorange.gui.concurrency.executor.EwoksExecutor.submit_task>`)
+  and runs them synchronously or on a background thread/process, re-entering
+  the GUI thread through Qt signals
+  (:attr:`~ewoksorange.gui.concurrency.executor.EwoksExecutor.started`,
+  :attr:`~ewoksorange.gui.concurrency.executor.EwoksExecutor.succeeded`,
+  :attr:`~ewoksorange.gui.concurrency.executor.EwoksExecutor.failed`).
+
+One execution cycle
+--------------------
+
+.. mermaid::
+
+    sequenceDiagram
+        participant SM as SignalManager (GUI thread)
+        participant W as OWEwoksBaseWidget (GUI thread)
+        participant EX as EwoksExecutor
+        participant BG as Background thread
+
+        Note over SM: 100ms timer fires, node is next in line
+        SM->>W: handleNewSignals()
+        W->>EX: submit_task()
+        Note right of EX: is_running -> True (synchronous)
+        EX->>BG: run Task.execute()
+        W->>W: progressBarInit()
+        Note right of SM: is_active(node) -> True
+
+        BG-->>BG: task runs
+        Note right of EX: is_running -> False (in worker thread,<br/>before any signal is delivered)
+        BG--)EX: Future done callback
+        EX--)W: succeeded/failed (queued across threads)
+
+        Note over W: GUI thread now runs __on_succeeded/__on_failed
+        W->>W: propagate_downstream()
+        W->>SM: Output.send() for each output
+        Note right of SM: has_pending() -> True for downstream nodes
+        W->>W: progressBarFinished()
+        Note right of SM: is_active(node) -> False
+
+        Note over SM: 100ms timer (re-armed), next node's turn
+
+Node "settledness"
+-------------------
+
+``SignalManager`` exposes predicates a caller can use to know whether there
+is still work in flight. A node cycles through five states; the same
+``Idle -> Queued`` transition applies whether the signal comes from the
+initial trigger or from an upstream node's propagation:
+
+.. mermaid::
+
+    stateDiagram-v2
+        [*] --> Idle
+
+        Idle --> Queued: Output.send() schedules<br/>a signal for this node
+        Queued --> Submitted: 100ms timer fires,<br/>process_node() calls<br/>handleNewSignals()
+        Submitted --> Running: queued 'started' signal delivered,<br/>progressBarInit() runs
+        Running --> Finishing: task completes<br/>on the background thread
+        Finishing --> Idle: queued 'succeeded'/'failed' delivered,<br/>propagate_downstream() sends outputs,<br/>then progressBarFinished() runs
+
+        note right of Queued
+            has_pending() == True
+        end note
+        note right of Submitted
+            is_running == True
+            is_active(node) == False
+            (submission gap)
+        end note
+        note right of Running
+            is_running == True
+            is_active(node) == True
+        end note
+        note right of Finishing
+            is_running == False
+            is_active(node) == True
+            (outputs not sent yet)
+        end note
+        note right of Idle
+            is_running == False
+            is_active(node) == False
+        end note
+
+The ``Submitted`` and ``Finishing`` states above are exactly where
+:attr:`is_running <ewoksorange.gui.concurrency.executor.EwoksExecutor.is_running>`
+and ``is_active(node)`` briefly disagree; see the two guarantees below for
+why polling both together is still reliable.
+
+A workflow is fully done once, for every node:
+
+- nothing is queued (not :meth:`signal_manager.has_pending() <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme.has_pending>`) and
+
+- nothing is executing (not :meth:`signal_manager.is_active(node) <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme.is_active>`).
+
+The task itself runs on a background thread, but ``is_active(node)`` only
+changes when Qt delivers a *queued* cross-thread signal, so it does not
+necessarily flip at the exact moment the task actually starts or finishes.
+Two ordering guarantees close that gap, so polling ``has_pending()`` and
+``is_active(node)`` never gives a false "idle" reading:
+
+- **Start:**
+  :attr:`EwoksExecutor.is_running <ewoksorange.gui.concurrency.executor.EwoksExecutor.is_running>`
+  flips to ``True`` synchronously at submission time, on the GUI thread —
+  before ``is_active(node)`` catches up (which needs the queued
+  :attr:`started <ewoksorange.gui.concurrency.executor.EwoksExecutor.started>`
+  signal to be delivered first, triggering
+  :meth:`progressBarInit() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.progressBarInit>`).
+  A caller must therefore check *both* ``is_active(node)`` and
+  ``task_executor.is_running`` to avoid a false "idle" reading right after
+  submission.
+- **Finish:** :class:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget` always
+  calls
+  :meth:`propagate_downstream() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.propagate_downstream>`
+  **before**
+  :meth:`progressBarFinished() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.progressBarFinished>`.
+  So the moment ``is_active(node)`` becomes ``False``, this widget's outputs
+  have already been sent (or invalidated), and any newly pending downstream
+  signal is already reflected by ``has_pending()``.
+
+See :meth:`~ewoksorange.gui.canvas.handler.OrangeCanvasHandler.wait_widgets`
+for the polling loop that uses these predicates to wait for a workflow to
+finish outside of the Orange canvas GUI.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,5 @@
-===========
-ewoksorange
-===========
+ewoksorange |version|
+=====================
 
 *ewoksorange* provides a desktop graphical interface for `ewoks <https://ewoks.readthedocs.io/>`_
 based on `biolab <https://github.com/biolab>`_ libraries `orange-canvas-core <https://github.com/biolab/orange-canvas-core>`_
@@ -28,4 +27,5 @@ of the `European Synchrotron <https://www.esrf.eu/>`_.
 
     tutorials
     howtoguides
+    explanations
     reference

--- a/doc/tutorials/starting_from_scratch.rst
+++ b/doc/tutorials/starting_from_scratch.rst
@@ -339,35 +339,6 @@ Notes
 Ewoks-Orange Execution Call Stack
 ---------------------------------
 
-When the user executes an Ewoks-Orange widget from the canvas, the following sequence occurs:
-
-.. mermaid::
-
-    sequenceDiagram
-        participant User
-        participant Widget
-        participant Task as Ewoks Task
-        participant Channel as Output Channel(s)
-        participant SignalManager
-        participant DownstreamWidget as Downstream Widget(s)
-
-        User->>Widget: Click "Trigger"
-        Widget->>Task: execute_ewoks_task()
-        Task->>Widget: propagate_downstream()
-
-        loop For each output channel
-            Widget->>Channel: send()
-            Channel->>SignalManager: send()
-        end
-
-        Task->>Widget: 🔧 task_output_changed() 🔧
-
-        loop For each connected output channel
-            SignalManager->>DownstreamWidget: set_dynamic_input(output_name, value)
-        end
-
-        SignalManager->>DownstreamWidget: 🔧 handleNewSignals() 🔧
-        Note over SignalManager,DownstreamWidget: One handleNewSignals() call per downstream widget
-        Note over Widget,Task: Concurrent Task Execution
-
-🔧 : to be implemented like in the ``OWExampleTask`` widget above.
+For how a widget's execution actually propagates to downstream widgets
+(signal manager scheduling, background task execution, ordering
+guarantees), see :doc:`../explanations/execution`.

--- a/src/ewoksorange/gui/canvas/handler.py
+++ b/src/ewoksorange/gui/canvas/handler.py
@@ -194,7 +194,6 @@ class OrangeCanvasHandler:
         widgets = list(self.iter_widgets())
         nodes = list(self.iter_nodes())
         t0 = time.time()
-        settled_streak = 0
 
         while True:
             self.process_events()
@@ -211,15 +210,34 @@ class OrangeCanvasHandler:
                     if exception is not None:
                         exceptions[widget] = exception
 
-            # Workflow finished?
+            # Workflow finished? All three checks below are needed, each
+            # closing a different gap between a task's real state and what
+            # the canvas machinery reports:
             #
-            # `signal_manager.is_active(node)` only turns True once the
-            # widget's `progressBarInit` slot has run, which itself only
-            # happens once Qt has delivered the executor's `started` signal
-            # (queued, since it is emitted from a background thread). A task
-            # can therefore be submitted and briefly look inactive before
-            # that signal is delivered. `TaskFuture` submission is tracked
-            # synchronously, so check it too.
+            # - `has_pending()`: nothing queued for delivery. A widget's
+            #   outputs are scheduled by `propagate_downstream()` (see
+            #   below) before its progress bar is cleared, so this stays
+            #   True until the signal manager's timer has actually
+            #   delivered them to downstream nodes.
+            # - `is_active(node)`: no node's progress bar is running. This
+            #   is the only signal available for a native `OWWidget` (it
+            #   has no `task_executor`), but for an Ewoks widget it only
+            #   turns True once Qt has delivered the executor's `started`
+            #   signal (queued, since it is emitted from a background
+            #   thread) - a task can be submitted and briefly look
+            #   inactive before that signal arrives.
+            # - `no_running_tasks`: no Ewoks task is currently
+            #   submitted/executing, checked synchronously via
+            #   `task_executor.is_running` instead of waiting for a
+            #   signal. This closes the submission gap `is_active(node)`
+            #   misses above.
+            #
+            # `OWEwoksBaseWidget`'s `__on_succeeded`/`__on_failed`
+            # callbacks always call `propagate_downstream()` before
+            # `progressBarFinished()` clears `is_active(node)`. So once
+            # `is_active(node)` is False and no task is running, this
+            # widget's outputs (or invalidation) are already scheduled,
+            # and `has_pending()` already reflects that.
             no_running_tasks = not any(
                 getattr(widget, "task_executor", None) is not None
                 and widget.task_executor.is_running
@@ -230,12 +248,7 @@ class OrangeCanvasHandler:
                 and not any(signal_manager.is_active(node) for node in nodes)
                 and no_running_tasks
             )
-            settled_streak = settled_streak + 1 if settled else 0
-            # Require two consecutive settled reads: a node can finish (e.g.
-            # a background thread) and briefly look settled before its
-            # output signal has actually been scheduled for delivery to
-            # downstream nodes.
-            if settled_streak >= 2:
+            if settled:
                 if exceptions:
                     raise next(iter(exceptions.values()))
                 break

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -91,11 +91,16 @@ class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__last_task_succeeded = True
         self.__last_task_done = True
         self.__last_task_exception = None
-        self.progressBarFinished()
+        # `propagate_downstream` must run before `progressBarFinished`: the
+        # latter flips `signal_manager.is_active(node)` to False, which is
+        # what `wait_widgets`-style polling relies on to know this widget is
+        # done. Clearing it first would let such polling observe "not
+        # active" before the outputs were actually sent downstream.
         try:
             if propagate:
                 self.propagate_downstream(succeeded=True)
         finally:
+            self.progressBarFinished()
             self._output_changed()
 
     def __on_failed(self, task_future: TaskFuture) -> None:
@@ -104,11 +109,12 @@ class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.__last_task_succeeded = False
         self.__last_task_done = True
         self.__last_task_exception = task_future.exception()
-        self.progressBarFinished()
+        # See ordering note in `__on_succeeded`.
         try:
             if propagate:
                 self.propagate_downstream(succeeded=False)
         finally:
+            self.progressBarFinished()
             self._output_changed()
 
     @property


### PR DESCRIPTION
In addition to the fix, I added docs on the "Execution Lifecycle" of an Orange workflow.

The two mermaid diagrams in the docs (LLM used to track the calls and make the diagrams):

1. One execution cycle

<img width="1296" height="1022" alt="image" src="https://github.com/user-attachments/assets/294833b3-d7d2-4668-8627-8d533d203fcc" />

2. Node “settledness”

<img width="895" height="1085" alt="image" src="https://github.com/user-attachments/assets/1baf75f2-3c80-4eda-809b-1e182e0868d6" />
