### PR TITLE
use OWEwoksBaseWidget.has_pending_task() instead of EwoksExecutor.is_running()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ̀`OWEwoksBaseWidget`: `execute_ewoks_task` now returns `TaskFuture` or `None` when the execution
   request was dropped.
+- ̀`OWEwoksBaseWidget`: derived classes need to implement `is_ewoks_task_running`.
 
 ### Deprecated
 

--- a/doc/explanations/execution.rst
+++ b/doc/explanations/execution.rst
@@ -45,13 +45,13 @@ One execution cycle
         Note over SM: 100ms timer fires, node is next in line
         SM->>W: handleNewSignals()
         W->>EX: submit_task()
-        Note right of EX: is_running -> True (synchronous)
+        Note right of W: has_pending_task() -> True (synchronous)
         EX->>BG: run Task.execute()
         W->>W: progressBarInit()
         Note right of SM: is_active(node) -> True
 
         BG-->>BG: task runs
-        Note right of EX: is_running -> False (in worker thread,<br/>before any signal is delivered)
+        Note right of BG: has_pending_task() -> still True<br/>(succeeded/failed not delivered yet)
         BG--)EX: Future done callback
         EX--)W: succeeded/failed (queued across threads)
 
@@ -61,16 +61,29 @@ One execution cycle
         Note right of SM: has_pending() -> True for downstream nodes
         W->>W: progressBarFinished()
         Note right of SM: is_active(node) -> False
+        Note right of W: has_pending_task() -> False
 
         Note over SM: 100ms timer (re-armed), next node's turn
 
 Node "settledness"
 -------------------
 
-``SignalManager`` exposes predicates a caller can use to know whether there
-is still work in flight. A node cycles through five states; the same
-``Idle -> Queued`` transition applies whether the signal comes from the
-initial trigger or from an upstream node's propagation:
+There is no single "is this workflow done?" flag. "Settled" is spread
+across three independent flags, each owned by a different layer, each
+covering a different slice of one widget's execution:
+
+:meth:`has_pending_task() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.has_pending_task>` (widget)
+    True while a task submission hasn't reached its GUI-thread completion
+    callback yet.
+:meth:`is_active(node) <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme.is_active>` (canvas)
+    True while the widget's progress bar is running.
+:meth:`has_pending() <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme.has_pending>` (canvas)
+    True while some node has a signal scheduled but not yet delivered.
+
+A workflow is settled only once **every one** of these reads "not busy",
+for every node and widget. A node cycles through five states on the way
+there; the same ``Idle -> Queued`` transition applies whether the signal
+comes from the initial trigger or from an upstream node's propagation:
 
 .. mermaid::
 
@@ -87,60 +100,58 @@ initial trigger or from an upstream node's propagation:
             has_pending() == True
         end note
         note right of Submitted
-            is_running == True
+            has_pending_task() == True
             is_active(node) == False
             (submission gap)
         end note
         note right of Running
-            is_running == True
+            has_pending_task() == True
             is_active(node) == True
         end note
         note right of Finishing
-            is_running == False
+            has_pending_task() == True
             is_active(node) == True
             (outputs not sent yet)
         end note
         note right of Idle
-            is_running == False
+            has_pending_task() == False
             is_active(node) == False
         end note
 
-The ``Submitted`` and ``Finishing`` states above are exactly where
-:attr:`is_running <ewoksorange.gui.concurrency.executor.EwoksExecutor.is_running>`
-and ``is_active(node)`` briefly disagree; see the two guarantees below for
-why polling both together is still reliable.
+The ``Submitted`` and ``Finishing`` states are exactly where a naive
+single-flag check would be fooled: the task's real state and what one
+flag reports can momentarily disagree. Checking all three together is
+only safe because of one rule, applied twice below: **a flag may only
+switch to "not busy" once whatever sits downstream of it already
+reflects the change** — never the other way around.
 
-A workflow is fully done once, for every node:
+1. ``has_pending()`` before ``is_active(node)``. Sending a task's
+   outputs
+   (:meth:`propagate_downstream() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.propagate_downstream>`)
+   is what schedules delivery to downstream nodes, flipping
+   ``has_pending()`` to ``True`` — and that call always happens
+   *before*
+   :meth:`progressBarFinished() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.progressBarFinished>`
+   clears ``is_active(node)``. So the moment ``is_active(node)`` is
+   observed ``False``, any output this widget just produced is already
+   visible through ``has_pending()``.
 
-- nothing is queued (not :meth:`signal_manager.has_pending() <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme.has_pending>`) and
+2. ``is_active(node)`` before ``has_pending_task()``. Both calls
+   above run *inside* the widget's GUI-thread ``succeeded``/``failed``
+   callback — the same callback that finally clears
+   ``has_pending_task()``. That callback executes as one
+   uninterrupted, non-reentrant step on the GUI thread (the same thread
+   `wait_widgets`-style polling runs on), so a poller can only ever see
+   it from before it starts or after it has fully finished — never
+   midway. So the moment ``has_pending_task()`` is observed
+   ``False``, guarantee 1 has already played out too: ``is_active(node)``
+   is already ``False`` and ``has_pending()`` already reflects it.
 
-- nothing is executing (not :meth:`signal_manager.is_active(node) <ewoksorange.gui.orange_utils.signal_manager.SignalManagerWithScheme.is_active>`).
-
-The task itself runs on a background thread, but ``is_active(node)`` only
-changes when Qt delivers a *queued* cross-thread signal, so it does not
-necessarily flip at the exact moment the task actually starts or finishes.
-Two ordering guarantees close that gap, so polling ``has_pending()`` and
-``is_active(node)`` never gives a false "idle" reading:
-
-- **Start:**
-  :attr:`EwoksExecutor.is_running <ewoksorange.gui.concurrency.executor.EwoksExecutor.is_running>`
-  flips to ``True`` synchronously at submission time, on the GUI thread —
-  before ``is_active(node)`` catches up (which needs the queued
-  :attr:`started <ewoksorange.gui.concurrency.executor.EwoksExecutor.started>`
-  signal to be delivered first, triggering
-  :meth:`progressBarInit() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.progressBarInit>`).
-  A caller must therefore check *both* ``is_active(node)`` and
-  ``task_executor.is_running`` to avoid a false "idle" reading right after
-  submission.
-- **Finish:** :class:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget` always
-  calls
-  :meth:`propagate_downstream() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.propagate_downstream>`
-  **before**
-  :meth:`progressBarFinished() <ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.progressBarFinished>`.
-  So the moment ``is_active(node)`` becomes ``False``, this widget's outputs
-  have already been sent (or invalidated), and any newly pending downstream
-  signal is already reflected by ``has_pending()``.
+Chaining the two: checking ``has_pending_task()`` alone would be
+enough to know the other two are settled — but native ``OWWidget``\ s
+have no such flag, so ``is_active(node)`` is still checked directly for
+every node, and ``has_pending()`` for the signal manager as a whole.
 
 See :meth:`~ewoksorange.gui.canvas.handler.OrangeCanvasHandler.wait_widgets`
-for the polling loop that uses these predicates to wait for a workflow to
-finish outside of the Orange canvas GUI.
+for the polling loop that checks all three flags together to wait for a
+workflow to finish outside of the Orange canvas GUI.

--- a/src/ewoksorange/gui/canvas/handler.py
+++ b/src/ewoksorange/gui/canvas/handler.py
@@ -40,7 +40,7 @@ else:
 
         from . import config as orangeconfig
 
-from ..orange_utils.signal_manager import SignalManagerWithOutputTracking
+from ..orange_utils.signal_manager import SignalManagerWithScheme
 from ..owwidgets.base import OWEwoksBaseWidget
 from ..qt_utils import app as qt_app
 from ..workflows.representation import ows_file_context
@@ -124,9 +124,9 @@ class OrangeCanvasHandler:
         return self.canvas.current_document().scheme()
 
     @property
-    def signal_manager(self) -> SignalManagerWithOutputTracking:
+    def signal_manager(self) -> SignalManagerWithScheme:
         signal_manager = self.scheme.signal_manager
-        if not isinstance(signal_manager, SignalManagerWithOutputTracking):
+        if not isinstance(signal_manager, SignalManagerWithScheme):
             raise RuntimeError(
                 "Orange signal manager was not patched before instantiated"
             )
@@ -210,45 +210,26 @@ class OrangeCanvasHandler:
                     if exception is not None:
                         exceptions[widget] = exception
 
-            # Workflow finished? All three checks below are needed, each
-            # closing a different gap between a task's real state and what
-            # the canvas machinery reports:
+            # Workflow "settled"? Meaning nothing happens anymore.
             #
-            # - `has_pending()`: nothing queued for delivery. A widget's
-            #   outputs are scheduled by `propagate_downstream()` (see
-            #   below) before its progress bar is cleared, so this stays
-            #   True until the signal manager's timer has actually
-            #   delivered them to downstream nodes.
-            # - `is_active(node)`: no node's progress bar is running. This
-            #   is the only signal available for a native `OWWidget` (it
-            #   has no `task_executor`), but for an Ewoks widget it only
-            #   turns True once Qt has delivered the executor's `started`
-            #   signal (queued, since it is emitted from a background
-            #   thread) - a task can be submitted and briefly look
-            #   inactive before that signal arrives.
-            # - `no_running_tasks`: no Ewoks task is currently
-            #   submitted/executing, checked synchronously via
-            #   `task_executor.is_running` instead of waiting for a
-            #   signal. This closes the submission gap `is_active(node)`
-            #   misses above.
+            # "Settled" is split across three flags, each owned by a
+            # different layer. ALL of them must read "not busy" for the
+            # workflow to be settled.
             #
-            # `OWEwoksBaseWidget`'s `__on_succeeded`/`__on_failed`
-            # callbacks always call `propagate_downstream()` before
-            # `progressBarFinished()` clears `is_active(node)`. So once
-            # `is_active(node)` is False and no task is running, this
-            # widget's outputs (or invalidation) are already scheduled,
-            # and `has_pending()` already reflects that.
-            no_running_tasks = not any(
-                getattr(widget, "task_executor", None) is not None
-                and widget.task_executor.is_running
+            # A flag is only allowed to switch to "not busy" once whatever
+            # sits downstream of it already reflects that, so checking all
+            # three together never gives a false "idle" reading.
+            #
+            # See doc/explanations/execution.rst ("Node settledness") for the
+            # full reasoning.
+            no_pending_signals = not signal_manager.has_pending()
+            no_active_nodes = not any(signal_manager.is_active(node) for node in nodes)
+            no_pending_tasks = not any(
+                isinstance(widget, OWEwoksBaseWidget) and widget.has_pending_task()
                 for widget in widgets
             )
-            settled = (
-                not signal_manager.has_pending()
-                and not any(signal_manager.is_active(node) for node in nodes)
-                and no_running_tasks
-            )
-            if settled:
+
+            if no_pending_signals and no_active_nodes and no_pending_tasks:
                 if exceptions:
                     raise next(iter(exceptions.values()))
                 break

--- a/src/ewoksorange/gui/concurrency/executor.py
+++ b/src/ewoksorange/gui/concurrency/executor.py
@@ -76,17 +76,6 @@ class EwoksExecutor(QObject):
 
         self._manager: Optional[multiprocessing.managers.SyncManager] = None
 
-    @property
-    def is_running(self) -> bool:
-        """Whether a task is currently submitted or executing.
-
-        Unlike the Qt `started`/`succeeded`/`failed` signals, this reflects
-        the submission state synchronously, without waiting for a
-        (possibly cross-thread, queued) signal to be delivered.
-        """
-        with self._lock:
-            return self._running > 0
-
     def submit_task(
         self, task_class: Type[Task], **task_kwargs
     ) -> Optional[TaskFuture]:

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import functools
 import logging
 import warnings
+from abc import abstractmethod
 from typing import Any
 from typing import Callable
 from typing import List
@@ -65,7 +66,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
 
     Subclasses must implement:
 
-    - methods: get_task_outputs, _execute_ewoks_task
+    - methods: _get_task_outputs, _execute_ewoks_task, has_pending_task
     - properties: task_succeeded, task_done, task_exception
     """
 
@@ -479,6 +480,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             }
         return outputs
 
+    @abstractmethod
     def _get_task_outputs(self) -> dict:
         raise NotImplementedError("Base class")
 
@@ -638,6 +640,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         return self._execute_ewoks_task(propagate=False, log_missing_inputs=False)
 
     @property
+    @abstractmethod
     def task_succeeded(self) -> Optional[bool]:
         """
         Whether the most recent task execution succeeded.
@@ -647,6 +650,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         raise NotImplementedError("Base class")
 
     @property
+    @abstractmethod
     def task_done(self) -> Optional[bool]:
         """
         Whether the most recent task execution finished (success or failure).
@@ -656,11 +660,22 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         raise NotImplementedError("Base class")
 
     @property
+    @abstractmethod
     def task_exception(self) -> Optional[Exception]:
         """
         Exception raised during the most recent task execution, if any.
 
         :return: Exception instance or None.
+        """
+        raise NotImplementedError("Base class")
+
+    @abstractmethod
+    def has_pending_task(self) -> bool:
+        """
+        Whether a task submission is outstanding, from submission until its
+        completion callback (propagation + `progressBarFinished`) has run.
+
+        :return: True while a submission is outstanding.
         """
         raise NotImplementedError("Base class")
 
@@ -738,6 +753,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             if ncallbacks > 1:
                 self.__post_task_execute(callbacks[1:])
 
+    @abstractmethod
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
     ) -> Optional[TaskFuture]:

--- a/src/ewoksorange/gui/owwidgets/meta.py
+++ b/src/ewoksorange/gui/owwidgets/meta.py
@@ -3,6 +3,7 @@ Metaclass and class preparation utilities for owwidgets package.
 """
 
 import inspect
+from abc import ABCMeta
 from typing import Any
 
 from ...orange_version import ORANGE_VERSION
@@ -23,7 +24,7 @@ else:
 from ..orange_utils import _signals
 
 
-class OWEwoksWidgetMetaClass(WidgetMetaClass):
+class OWEwoksWidgetMetaClass(ABCMeta, WidgetMetaClass):
     """
     Metaclass used to prepare widget classes with Ewoks bindings.
     """

--- a/src/ewoksorange/gui/owwidgets/nothread.py
+++ b/src/ewoksorange/gui/owwidgets/nothread.py
@@ -59,6 +59,10 @@ class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
 
         return task_future
 
+    def has_pending_task(self) -> bool:
+        """Always False: submission runs synchronously to completion."""
+        return False
+
     @property
     def task_succeeded(self) -> Optional[bool]:
         """Return True if last task succeeded, False if failed, None if never run."""

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -122,6 +122,9 @@ class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         """The underlying :class:`EwoksExecutor`."""
         return self.__executor
 
+    def has_pending_task(self) -> bool:
+        return bool(self.__propagate_by_future)
+
     @property
     def task_succeeded(self) -> Optional[bool]:
         return self.__last_task_succeeded


### PR DESCRIPTION
`EwoksExecutor.is_running` was removed and replaced by `OWEwoksBaseWidget.has_pending_task`.

`is_running` cleared on the worker thread the instant the future finished, before its succeeded/failed signal even reached the GUI thread. `has_pending_task()` fixes that for `wait_widgets()`.

The doc under "node settledness" was modified to reflect that the "settledness state" exists in 3 locations and when changing one state, ensure first that the downstream state is changed.