### PR TITLE
execution: propagate before changing local state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ̀`OWEwoksBaseWidget`: `execute_ewoks_task` now returns `TaskFuture` or `None` when the execution
   request was dropped.
-- ̀`OWEwoksBaseWidget`: derived classes need to implement `is_ewoks_task_running`.
+- ̀`OWEwoksBaseWidget`: derived classes need to implement `has_pending_task`.
 
 ### Deprecated
 

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -86,7 +86,7 @@ class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         self.progressBarInit()
 
     def __on_succeeded(self, task_future: TaskFuture) -> None:
-        propagate = self.__propagate_by_future.pop(task_future, False)
+        propagate = self.__propagate_by_future.get(task_future, False)
         self.__last_output_variables = task_future.result()
         self.__last_task_succeeded = True
         self.__last_task_done = True
@@ -96,15 +96,18 @@ class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
         # what `wait_widgets`-style polling relies on to know this widget is
         # done. Clearing it first would let such polling observe "not
         # active" before the outputs were actually sent downstream.
+        # `has_pending_task()` must stay True until both of those have run,
+        # for the same reason, so the future is only popped last.
         try:
             if propagate:
                 self.propagate_downstream(succeeded=True)
         finally:
             self.progressBarFinished()
+            self.__propagate_by_future.pop(task_future, None)
             self._output_changed()
 
     def __on_failed(self, task_future: TaskFuture) -> None:
-        propagate = self.__propagate_by_future.pop(task_future, False)
+        propagate = self.__propagate_by_future.get(task_future, False)
         self.__last_output_variables = {}
         self.__last_task_succeeded = False
         self.__last_task_done = True
@@ -115,6 +118,7 @@ class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
                 self.propagate_downstream(succeeded=False)
         finally:
             self.progressBarFinished()
+            self.__propagate_by_future.pop(task_future, None)
             self._output_changed()
 
     @property


### PR DESCRIPTION
We [already established in the docs](https://github.com/ewoks-kit/ewoksorange/pull/450/changes#diff-929248080e5adb4b10bd5c5d5d0fb38ae3cfbfee308aa4d6bcbe8eb9df67a049R124) that we need to propagate first and only then change the local state. Still I was missing this one.