### PR TITLE
move progress and EwoksExecutor to OWEwoksBaseWidget which is no longer abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `OWEwoksBaseWidget` executes the Ewoks task itself, configured by class arguments,
+  and drives the Orange progress bar.
+- `OWEwoksWidgetNoThread`, `OWEwoksWidgetOneThread`, `OWEwoksWidgetOneThreadPerRun`
+  and `OWEwoksWidgetWithTaskStack` set the class arguments and nothing else.
+- Orange widgets can execute their Ewoks task in a process pool.
+
+### Changed
+
+- `OWEwoksBaseWidget` is no longer abstract.
+- `OWEwoksWidgetNoThread` now drives the Orange progress bar like the others.
+
 ## [6.0.0rc4] - 2026-08-06
 
 ### Fixed
 
 - Fix `ParameterForm` file system selection in QT6 (Replace `QDialog.exec_` with `QDialog.exec`).
 - Store all graph attributes in OWS format.
-- `OrangeCanvasHandler.wait_widgets`: fix a race where a widget executing on a
-  background thread could briefly look "settled" (task finished, not active)
-  before its outputs were actually propagated downstream, by making
-  `OWEwoksBaseWidget` call `propagate_downstream` before `progressBarFinished`.
+- `OrangeCanvasHandler.wait_widgets`: check the running state instead of `widget_is_executed`
+  since it might be executed again.
 
 ### Added
 
@@ -28,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ̀`OWEwoksBaseWidget`: `execute_ewoks_task` now returns `TaskFuture` or `None` when the execution
   request was dropped.
-- ̀`OWEwoksBaseWidget`: derived classes need to implement `has_pending_task`.
 
 ### Deprecated
 

--- a/doc/explanations/execution.rst
+++ b/doc/explanations/execution.rst
@@ -65,6 +65,17 @@ One execution cycle
 
         Note over SM: 100ms timer (re-armed), next node's turn
 
+The diagram shows the default case, where the task runs on a background
+thread. The other backends only change who runs the task:
+
+``concurrency="sync"``
+    Every step runs on the GUI thread, inside the ``submit_task()`` call, so
+    ``handleNewSignals()`` only returns once the outputs have been propagated.
+``concurrency="process"``
+    A worker process runs the task. Its lifecycle events and progress travel
+    back over ``multiprocessing`` proxies, relayed onto the GUI thread by
+    :class:`~ewoksorange.gui.concurrency._controllers.process.ProcessTaskController`.
+
 Node "settledness"
 -------------------
 

--- a/doc/tutorials/ewoks_widgets.rst
+++ b/doc/tutorials/ewoks_widgets.rst
@@ -3,7 +3,9 @@
 Ewoks widgets and execution
 ===========================
 
-There are several ways of defining how your Orange Widget will handle the execution of its associated Ewoks task.
+All Ewoks widgets derive from :class:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget`,
+which executes the Ewoks task as :ref:`configured with class arguments
+<design configuration>`. The most common configurations also have a named class:
 
 * :ref:`design qt main thread (OWEwoksWidgetNoThread)`: simple, robust. Long processings can prevent the GUI from responding.
 * :ref:`design single thread no stack (OWEwoksWidgetOneThread)`: execution is separate from the GUI thread. Can only handle one task at once.
@@ -15,18 +17,54 @@ The choice of design depends on your use case: for example, if you deal with sma
 the first design (the simplest one) is the best. Other designs allow more flexibility but are more complex.
 
 
-.. table:: Differences between Ewoks widgets
+.. list-table:: Differences between Ewoks widgets
+   :header-rows: 1
    :widths: auto
 
-   ============================  =======================================  ============================    
-     Widget                       GUI is responsive during execution      Tasks can be run in parallel
-   ============================  =======================================  ============================  
-   OWEwoksWidgetNoThread            No                                     No                       
-   OWEwoksWidgetOneThread           Yes                                    No                       
-   OWEwoksWidgetOneThreadPerRun     Yes                                    Yes                        
-   OWEwoksWidgetWithTaskStack       Yes                                    Yes                        
-   No widget                        Depends on implementation              Depends on implementation 
-   ============================  =======================================  ============================  
+   * - Widget
+     - GUI is responsive during execution
+     - Tasks can be run in parallel
+   * - :ref:`OWEwoksWidgetNoThread <design qt main thread (OWEwoksWidgetNoThread)>`
+     - No
+     - No
+   * - :ref:`OWEwoksWidgetOneThread <design single thread no stack (OWEwoksWidgetOneThread)>`
+     - Yes
+     - No
+   * - :ref:`OWEwoksWidgetOneThreadPerRun <design several thread (OWEwoksWidgetOneThreadPerRun)>`
+     - Yes
+     - Yes
+   * - :ref:`OWEwoksWidgetWithTaskStack <design single thread and stack (OWEwoksWidgetWithTaskStack)>`
+     - Yes
+     - Yes
+   * - :ref:`Native Orange widget <design free implementation (No direct ewoks inheritance)>`
+     - Depends
+     - Depends
+
+.. _design configuration:
+
+Configure the base widget
+-------------------------
+
+Instead of picking one of the classes above, the execution strategy can be given
+directly to :class:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget`
+
+.. code-block:: python
+
+    from ewoksorange.gui.owwidgets.base import OWEwoksBaseWidget
+    from ewokscore.tests.examples.tasks.sumtask import SumTask
+
+    class OWSumTask(
+        OWEwoksBaseWidget,
+        ewokstaskclass=SumTask,
+        concurrency="process",   # "sync", "thread" (default) or "process"
+        max_workers=2,           # None for the pool default
+        submit_policy="always",  # or "drop_if_busy" while the executor is busy
+        mp_context="spawn",      # "spawn" (default), "fork", "forkserver" or None
+    ):
+        pass
+
+Class arguments that are not provided are inherited, so a subclass can change one
+knob without repeating the others.
 
 
 .. _design qt main thread (OWEwoksWidgetNoThread):
@@ -107,9 +145,11 @@ For this, make the Orange widget inherit from :class:`OWEwoksWidgetOneThread`
 
 
 
-The Orange widget is holding a processing thread (`_processingThread`) that will execute the `ewokstaskclass`.
+The Orange widget holds a single-threaded executor
+(:attr:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget.task_executor`) that will
+execute the `ewokstaskclass`.
 
-.. note:: 
+.. note::
     
     The thread can only execute one task at a time: it will refuse to execute further tasks if the current task is still executing. 
     
@@ -176,8 +216,6 @@ To access it you can create a widget inheriting from :class:`OWEwoksWidgetWithTa
 
         want_main_area = False
 
-
-The :class:`SumListWithTaskStack` holds an instance of `progress` in its task arguments.
 
 .. _design free implementation (No direct ewoks inheritance):
 

--- a/src/ewoksorange/gui/concurrency/_controllers/abstract.py
+++ b/src/ewoksorange/gui/concurrency/_controllers/abstract.py
@@ -38,3 +38,19 @@ class TaskController(ABC):
         No-op by default, since most controllers report "started" and
         completion through the same channel, in order.
         """
+
+    def watch_progress(self, on_progress: Callable[[int], None]) -> None:
+        """Register `on_progress` to be called for every progress value the
+        task reports.
+
+        Optional: only meaningful for controllers where the task cannot update
+        the caller's progress object directly.
+        """
+        raise NotImplementedError(f"{type(self).__name__} has no progress watcher")
+
+    def stop_progress(self) -> None:
+        """Stop watching progress, after delivering everything received so far.
+
+        No-op by default, since most controllers let the task update the
+        caller's progress object directly.
+        """

--- a/src/ewoksorange/gui/concurrency/_controllers/process.py
+++ b/src/ewoksorange/gui/concurrency/_controllers/process.py
@@ -5,6 +5,7 @@ from queue import Queue
 from typing import Callable
 from typing import Optional
 
+from .._progress import PROGRESS_STOP
 from .abstract import TaskController
 
 _logger = logging.getLogger(__name__)
@@ -22,12 +23,15 @@ class ProcessTaskController(TaskController):
         abort_event: Event,
         aborted_event: Event,
         started_queue: Queue,
+        progress_queue: Queue,
     ):
         self._abort_event = abort_event
         self._aborted_event = aborted_event
         self._started_queue = started_queue
         self._started_handled = threading.Event()
         self._on_started_thread: Optional[threading.Thread] = None
+        self._progress_queue = progress_queue
+        self._on_progress_thread: Optional[threading.Thread] = None
 
     def watch_started(self, on_started: Callable[[], None]) -> None:
         """Call `on_started` once the child process reports it has started."""
@@ -58,6 +62,46 @@ class ProcessTaskController(TaskController):
             self._on_started_thread.join(timeout=5.0)
             if self._on_started_thread.is_alive():
                 _logger.debug("started relay thread did not terminate in time")
+
+    def watch_progress(self, on_progress: Callable[[int], None]) -> None:
+        """Relay the progress values reported by the child process."""
+
+        def _relay():
+            while True:
+                try:
+                    value = self._progress_queue.get(timeout=300)
+                except Exception:
+                    _logger.debug("progress relay failed", exc_info=True)
+                    return
+                if value == PROGRESS_STOP:
+                    return
+                try:
+                    on_progress(value)
+                except Exception:
+                    _logger.debug("progress callback failed", exc_info=True)
+
+        self._on_progress_thread = threading.Thread(target=_relay, daemon=True)
+        self._on_progress_thread.start()
+
+    def stop_progress(self) -> None:
+        """Wait for all progress values to be relayed, then stop the relay.
+
+        The child puts every progress value before returning its result, while
+        the sentinel below is only put once the parent sees the task finished.
+        Manager queues are FIFO, so draining up to the sentinel delivers all of
+        them.
+        """
+        if self._on_progress_thread is None:
+            return
+
+        try:
+            self._progress_queue.put(PROGRESS_STOP)
+        except Exception:
+            _logger.debug("failed to stop the progress relay", exc_info=True)
+
+        self._on_progress_thread.join(timeout=5.0)
+        if self._on_progress_thread.is_alive():
+            _logger.debug("progress relay thread did not terminate in time")
 
     def abort(self) -> bool:
         self._abort_event.set()

--- a/src/ewoksorange/gui/concurrency/_progress.py
+++ b/src/ewoksorange/gui/concurrency/_progress.py
@@ -1,0 +1,31 @@
+"""
+Ewoks task progress across a process boundary.
+"""
+
+import queue
+
+from ewokscore.progress import BasePercentageProgress
+
+PROGRESS_STOP = "__stop__"
+"""Sentinel put on the queue by the parent process to stop the relay."""
+
+
+class QueueProgress(BasePercentageProgress):
+    """Picklable progress that forwards updates to the parent process."""
+
+    _TRANSIENT_ERRORS = (EOFError, BrokenPipeError, ConnectionError)
+    # The manager providing the queue shut down.
+
+    def __init__(self, progress_queue: queue.Queue):
+        """
+        :param progress_queue: A `multiprocessing` manager queue proxy.
+        """
+        super().__init__()
+        self._progress_queue = progress_queue
+
+    def _update(self) -> None:
+        """Send the current progress to the parent process."""
+        try:
+            self._progress_queue.put(self._progress)
+        except self._TRANSIENT_ERRORS:
+            pass

--- a/src/ewoksorange/gui/concurrency/_runners/abstract.py
+++ b/src/ewoksorange/gui/concurrency/_runners/abstract.py
@@ -6,7 +6,6 @@ from typing import Dict
 from typing import Tuple
 from typing import Type
 
-from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 from ewokscore.variable import VariableContainer
 
@@ -50,12 +49,7 @@ class TaskRunner(ABC):
 
     def _create_task(self) -> Task:
         """Instantiate task class."""
-        kwargs = dict(self._task_kwargs)
-
-        if not issubclass(self._task_class, TaskWithProgress):
-            kwargs.pop("progress", None)
-
-        return self._task_class(**kwargs)
+        return self._task_class(**self._task_kwargs)
 
     def _execute(self, task: Task) -> VariableContainer:
         """Execute `task`, cancelling it for as long as `abort_event` is set."""

--- a/src/ewoksorange/gui/concurrency/base.py
+++ b/src/ewoksorange/gui/concurrency/base.py
@@ -1,11 +1,13 @@
 import logging
 import warnings
+from typing import Mapping
 from typing import Optional
 from typing import Type
 
 from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 from ewokscore.task import TaskInputError
+from ewokscore.variable import Variable
 
 _logger = logging.getLogger(__name__)
 
@@ -76,7 +78,9 @@ class TaskExecutor:
         return self.__task.exception
 
     @property
-    def output_variables(self) -> Optional[dict]:
+    def output_variables(self) -> Mapping[str, Variable]:
+        """The task's :class:`~ewokscore.variable.VariableContainer`, or an empty
+        `dict` when there is no task."""
         if self.__task is None:
             return dict()
         return self.__task.output_variables

--- a/src/ewoksorange/gui/concurrency/executor.py
+++ b/src/ewoksorange/gui/concurrency/executor.py
@@ -2,24 +2,30 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
+import multiprocessing.context
 import multiprocessing.managers
 import weakref
 from concurrent import futures
 from enum import Enum
 from enum import auto
+from queue import Queue
 from threading import Event
 from threading import Lock
 from typing import Any
 from typing import Callable
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Type
 
 from AnyQt.QtCore import QObject
 from AnyQt.QtCore import Signal
+from ewokscore import TaskWithProgress
 from ewokscore.task import Task
+from ewokscore.variable import VariableContainer
 
 from . import _controllers
+from . import _progress
 from . import _runners
 from .future import TaskFuture
 
@@ -31,12 +37,49 @@ class SubmitPolicy(Enum):
     DROP_IF_BUSY = auto()
 
 
+class Concurrency(Enum):
+    """How an :class:`EwoksExecutor` executes ewoks tasks."""
+
+    SYNC = auto()
+    """In the calling thread."""
+
+    THREAD = auto()
+    """In a thread pool."""
+
+    PROCESS = auto()
+    """In a process pool."""
+
+
+def create_pool_executor(
+    concurrency: Concurrency,
+    max_workers: Optional[int] = None,
+    mp_context: Optional[multiprocessing.context.BaseContext] = None,
+) -> Optional[futures.Executor]:
+    """Create the `concurrent.futures` executor for a given concurrency.
+
+    :param concurrency: The execution backend.
+    :param max_workers: Maximum number of workers, `None` for the pool default.
+                        Ignored for `Concurrency.SYNC`.
+    :param mp_context: Multiprocessing context, only used for `Concurrency.PROCESS`.
+    :return: The executor, or `None` for `Concurrency.SYNC`.
+    """
+    if concurrency is Concurrency.SYNC:
+        return None
+    if concurrency is Concurrency.PROCESS:
+        return futures.ProcessPoolExecutor(
+            max_workers=max_workers, mp_context=mp_context
+        )
+    return futures.ThreadPoolExecutor(max_workers=max_workers)
+
+
 class EwoksExecutor(QObject):
     """Qt-aware executor for ewoks tasks.
 
     Wraps a `concurrent.futures.Executor` (thread, process or None) and emits Qt
     signals on task lifecycle events. Returns TaskFuture objects that support
     both native future cancellation (cancel()) and ewoks task abort (abort()).
+    Their result is the executed task's
+    :class:`~ewokscore.variable.VariableContainer` of output variables.
     """
 
     submitted = Signal(TaskFuture)
@@ -64,11 +107,20 @@ class EwoksExecutor(QObject):
         self,
         executor: Optional[futures.Executor],
         policy: SubmitPolicy = SubmitPolicy.ALWAYS,
+        mp_context: Optional[multiprocessing.context.BaseContext] = None,
     ):
+        """
+        :param executor: Wrapped executor, `None` to execute in the calling thread.
+        :param policy: What to do with submissions while the executor is busy.
+        :param mp_context: Multiprocessing context used for the IPC manager. Provide
+                           the context of `executor` so the manager process is created
+                           with the same start method.
+        """
         super().__init__()
 
         self._executor = executor
         self._policy = policy
+        self._mp_context = mp_context
         self._running = 0
         self._lock = Lock()
 
@@ -96,10 +148,13 @@ class EwoksExecutor(QObject):
 
         return self._submit_thread(task_class, task_kwargs)
 
-    def _submit_sync(self, task_class: Type[Task], task_kwargs: dict) -> TaskFuture:
+    def _submit_sync(
+        self, task_class: Type[Task], task_kwargs: Dict[str, Any]
+    ) -> TaskFuture:
         controller = _controllers.SyncTaskController()
         self_ref = weakref.ref(self)
         holder: List[Optional[TaskFuture]] = [None]
+        task_kwargs = self._handle_progess_arg(task_class, task_kwargs)
         runner = _runners.SyncTaskRunner(
             task_class,
             task_kwargs,
@@ -107,7 +162,7 @@ class EwoksExecutor(QObject):
             on_started=lambda: _emit_started(self_ref, holder),
         )
 
-        raw_future = futures.Future()
+        raw_future: futures.Future[VariableContainer] = futures.Future()
 
         return self._finalize_submission(
             raw_future,
@@ -117,11 +172,14 @@ class EwoksExecutor(QObject):
             after_submitted=lambda: _sync_submit(runner, raw_future),
         )
 
-    def _submit_thread(self, task_class: Type[Task], task_kwargs: dict) -> TaskFuture:
+    def _submit_thread(
+        self, task_class: Type[Task], task_kwargs: Dict[str, Any]
+    ) -> TaskFuture:
         controller = _controllers.ThreadTaskController()
         ready_event = Event()
         self_ref = weakref.ref(self)
         holder: List[Optional[TaskFuture]] = [None]
+        task_kwargs = self._handle_progess_arg(task_class, task_kwargs)
         runner = _runners.ThreadTaskRunner(
             task_class,
             task_kwargs,
@@ -136,17 +194,25 @@ class EwoksExecutor(QObject):
             raw_future, controller, holder, self_ref, after_submitted=ready_event.set
         )
 
-    def _submit_process(self, task_class: Type[Task], task_kwargs: dict) -> TaskFuture:
+    def _submit_process(
+        self, task_class: Type[Task], task_kwargs: Dict[str, Any]
+    ) -> TaskFuture:
         manager = self._get_manager()
 
         ready_event = manager.Event()
         started_queue = manager.Queue()
+        progress_queue = manager.Queue()
         abort_event = manager.Event()
         aborted_event = manager.Event()
 
         controller = _controllers.ProcessTaskController(
-            abort_event, aborted_event, started_queue
+            abort_event, aborted_event, started_queue, progress_queue
         )
+
+        task_kwargs = self._handle_progess_arg(
+            task_class, task_kwargs, controller, progress_queue
+        )
+
         runner = _runners.ProcessTaskRunner(
             task_class,
             task_kwargs,
@@ -166,9 +232,43 @@ class EwoksExecutor(QObject):
             raw_future, controller, holder, self_ref, after_submitted=ready_event.set
         )
 
+    def _handle_progess_arg(
+        self,
+        task_class: Type[Task],
+        task_kwargs: Dict[str, Any],
+        controller: Optional[_controllers.ProcessTaskController] = None,
+        progress_queue: Optional[Queue] = None,
+    ) -> Dict[str, Any]:
+        """Prepare the `progress` task argument for `task_class`.
+
+        Dropped outright if `task_class` does not support progress reporting.
+
+        For a process backend, the caller's progress object is usually
+        unpicklable (QObject), so it's replaced by a queue-backed
+        stand-in relaying values back to it.
+
+        :return: The task arguments to submit.
+        """
+        if "progress" not in task_kwargs:
+            return task_kwargs
+
+        task_kwargs = dict(task_kwargs)
+        progress = task_kwargs.pop("progress")
+
+        if progress is None or not issubclass(task_class, TaskWithProgress):
+            return task_kwargs
+
+        if controller is None or progress_queue is None:
+            task_kwargs["progress"] = progress
+            return task_kwargs
+
+        task_kwargs["progress"] = _progress.QueueProgress(progress_queue)
+        controller.watch_progress(lambda value: setattr(progress, "progress", value))
+        return task_kwargs
+
     def _finalize_submission(
         self,
-        raw_future: futures.Future,
+        raw_future: futures.Future[VariableContainer],
         controller: _controllers.TaskController,
         holder: List[Optional[TaskFuture]],
         self_ref: weakref.ReferenceType["EwoksExecutor"],
@@ -190,18 +290,24 @@ class EwoksExecutor(QObject):
 
     def _get_manager(self) -> multiprocessing.managers.SyncManager:
         if self._manager is None:
-            self._manager = multiprocessing.Manager()
+            context = self._mp_context or multiprocessing
+            self._manager = context.Manager()
 
         return self._manager
 
     def _handle_done(
         self,
-        raw_future: futures.Future,
+        raw_future: futures.Future[VariableContainer],
         task_future: TaskFuture,
         controller: _controllers.TaskController,
     ) -> None:
         with self._lock:
             self._running -= 1
+
+        # Before emitting anything: this delivers the progress values still in
+        # flight, so receivers of "succeeded"/"failed" cannot observe progress
+        # arriving after they considered the task finished.
+        controller.stop_progress()
 
         if raw_future.cancelled():
             return
@@ -234,7 +340,7 @@ class EwoksExecutor(QObject):
 
 def _done_callback(
     executor_ref: weakref.ReferenceType[EwoksExecutor],
-    raw_future: futures.Future,
+    raw_future: futures.Future[VariableContainer],
     task_future: TaskFuture,
     controller: _controllers.TaskController,
 ) -> None:
@@ -252,7 +358,10 @@ def _emit_started(
         executor.started.emit(holder[0])
 
 
-def _sync_submit(fn: Callable[[], Any], raw_future: futures.Future) -> None:
+def _sync_submit(
+    fn: Callable[[], VariableContainer],
+    raw_future: futures.Future[VariableContainer],
+) -> None:
     """Run `fn` and store its outcome in `raw_future`."""
     # `ThreadPoolExecutor`/`ProcessPoolExecutor` already do this internally
     # (via `set_running_or_notify_cancel()`) before invoking a submitted

--- a/src/ewoksorange/gui/concurrency/executor.py
+++ b/src/ewoksorange/gui/concurrency/executor.py
@@ -11,6 +11,7 @@ from enum import auto
 from queue import Queue
 from threading import Event
 from threading import Lock
+from threading import Thread
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -330,12 +331,23 @@ class EwoksExecutor(QObject):
             self.finished.emit(task_future)
 
     def shutdown(self, wait: bool = False) -> None:
-        if self._executor is not None:
-            self._executor.shutdown(wait=wait)
+        executor, self._executor = self._executor, None
+        manager, self._manager = self._manager, None
 
-        if self._manager is not None:
-            self._manager.shutdown()
-            self._manager = None
+        def _shutdown() -> None:
+            if executor is not None:
+                executor.shutdown(wait=True)
+            if manager is not None:
+                manager.shutdown()
+
+        if wait:
+            _shutdown()
+            return
+
+        # Wait off-thread rather than `executor.shutdown(wait=False)`: on
+        # Python < 3.9, garbage-collecting a `ProcessPoolExecutor` mid-shutdown
+        # can orphan a worker process, hanging the interpreter at exit.
+        Thread(target=_shutdown, name="EwoksExecutorShutdown").start()
 
 
 def _done_callback(

--- a/src/ewoksorange/gui/concurrency/future.py
+++ b/src/ewoksorange/gui/concurrency/future.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
 from concurrent.futures import Future
+from typing import Any
+from typing import Callable
+from typing import Optional
+
+from ewokscore.variable import VariableContainer
 
 from . import _controllers
 
@@ -8,7 +15,7 @@ class TaskFuture:
 
     def __init__(
         self,
-        raw_future: Future,
+        raw_future: Future[VariableContainer],
         controller: _controllers.TaskController,
     ):
         self._future = raw_future
@@ -44,11 +51,23 @@ class TaskFuture:
     def done(self) -> bool:
         return self._future.done()
 
-    def result(self, timeout=None):
+    def result(self, timeout: Optional[float] = None) -> VariableContainer:
+        """The output variables of the ewoks task.
+
+        :param timeout: Maximum number of seconds to wait, `None` to wait forever.
+        :raises TimeoutError: The task did not finish in time.
+        :raises CancelledError: The task was cancelled before it started.
+        :raises Exception: Whatever the task raised.
+        :return: An immutable mapping of output name to
+                 :class:`~ewokscore.variable.Variable`.
+        """
         return self._future.result(timeout=timeout)
 
-    def exception(self, timeout=None):
+    def exception(self, timeout: Optional[float] = None) -> Optional[BaseException]:
         return self._future.exception(timeout=timeout)
 
-    def add_done_callback(self, fn):
+    def add_done_callback(self, fn: Callable[[Future[VariableContainer]], Any]) -> None:
+        """
+        :param fn: Called with the wrapped future, not with this object.
+        """
         self._future.add_done_callback(fn)

--- a/src/ewoksorange/gui/orange_utils/signal_manager.py
+++ b/src/ewoksorange/gui/orange_utils/signal_manager.py
@@ -259,7 +259,10 @@ class SignalManagerWithScheme(
         self.invalidate_input_value(owwidget, channel.name, _MissingSignalValue())
 
     def widget_is_finished(self, owwidget) -> bool:
-        """Widget is executed for the last time and will not be execute again"""
+        """Widget is executed for the last time and will not be execute again.
+
+        .. warning:: deprecated since version 6.0
+        """
         if self.has_pending():
             return False  # The widget might be executed again
         return super().widget_is_executed(owwidget)

--- a/src/ewoksorange/gui/owwidgets/base.py
+++ b/src/ewoksorange/gui/owwidgets/base.py
@@ -1,15 +1,16 @@
 """
-Abstract base class for Ewoks-Orange widgets.
+Base class for Ewoks-Orange widgets.
 """
-
-from __future__ import annotations
 
 import functools
 import logging
+import multiprocessing
+import multiprocessing.context
 import warnings
-from abc import abstractmethod
+from concurrent import futures
 from typing import Any
 from typing import Callable
+from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -17,6 +18,8 @@ from typing import Set
 
 from AnyQt import QtWidgets
 from ewokscore import missing_data
+from ewokscore.variable import Variable
+from ewokscore.variable import VariableContainer
 from ewokscore.variable import value_from_transfer
 
 from ...orange_version import ORANGE_VERSION
@@ -36,14 +39,19 @@ else:
 
     OWWidget = OWBaseWidget
 
+from ..concurrency.executor import Concurrency
+from ..concurrency.executor import EwoksExecutor
+from ..concurrency.executor import SubmitPolicy
 from ..concurrency.executor import TaskFuture
+from ..concurrency.executor import create_pool_executor
 from ..orange_utils._signals import get_signal
 from ..orange_utils.orange_imports import OWBaseWidget
 from ..orange_utils.orange_imports import OWWidget
 from ..orange_utils.signals import Output
+from ..qt_utils.progress import QProgress
 from ..utils import invalid_data
 from ..utils.events import scheme_ewoks_events
-from ..utils.model import _get_model_default_values
+from ..utils.model import get_model_default_values
 from .meta import OWEwoksWidgetMetaClass
 from .meta import ow_build_opts
 
@@ -52,10 +60,11 @@ _logger = logging.getLogger(__name__)
 
 class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_opts):
     """
-    Abstract base class connecting Ewoks tasks with Orange workflow widgets.
+    Base class connecting Ewoks tasks with Orange workflow widgets.
 
-    This class manages inputs (default and dynamic), constructs task arguments,
-    and provides hooks for executing tasks and propagating outputs.
+    This class manages inputs (default and dynamic), executes the Ewoks task
+    through an :class:`~ewoksorange.gui.concurrency.executor.EwoksExecutor` and
+    propagates the outputs downstream.
 
     Default input values are saved in the workflow file.
     Typically default input values are provided by the user through a widget component.
@@ -64,10 +73,60 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
     Typically dynamic input values are send from the output if upstream tasks and wrapped
     by a `Variable` to handle things like Ewoks tasks output caching.
 
-    Subclasses must implement:
+    The Ewoks task class and the execution strategy are provided as class arguments:
 
-    - methods: _get_task_outputs, _execute_ewoks_task, has_pending_task
-    - properties: task_succeeded, task_done, task_exception
+    .. code-block:: python
+
+        class MyOwWidget(
+            OWEwoksBaseWidget,
+            ewokstaskclass=MyTask,
+            concurrency="thread",
+            max_workers=1,
+            submit_policy="always",
+            mp_context="spawn",
+        ):
+            ...
+
+    The defaults execute tasks one-at-a-time in a single background thread,
+    queueing submissions that arrive while busy.
+    """
+
+    _CONCURRENCY: Concurrency = Concurrency.THREAD
+    """Task execution backend, provided by the `concurrency` class argument.
+
+    - `Concurrency.SYNC` (`"sync"`): execute in the calling (GUI) thread.
+    - `Concurrency.THREAD` (`"thread"`): execute in a thread pool.
+    - `Concurrency.PROCESS` (`"process"`): execute in a process pool. This requires
+      all task inputs and outputs to be picklable.
+    """
+
+    _MAX_WORKERS: Optional[int] = 1
+    """Maximum number of task workers, provided by the `max_workers` class argument.
+    Ignored for `Concurrency.SYNC`.
+
+    - `1`: execute one task at a time.
+    - `n > 1`: execute at most `n` tasks at a time.
+    - `None`: use the pool default.
+    """
+
+    _SUBMIT_POLICY: SubmitPolicy = SubmitPolicy.ALWAYS
+    """What to do with a task submission while the executor is busy, provided by
+    the `submit_policy` class argument.
+
+    - `SubmitPolicy.ALWAYS` (`"always"`): submit, so it runs when a worker is free.
+    - `SubmitPolicy.DROP_IF_BUSY` (`"drop_if_busy"`): drop the submission.
+    """
+
+    _MP_CONTEXT: Optional[multiprocessing.context.BaseContext] = (
+        multiprocessing.get_context("spawn")
+    )
+    """Multiprocessing context for the task workers and their IPC manager, provided
+    by the `mp_context` class argument as a context or a start method name. Only
+    used for `Concurrency.PROCESS`.
+
+    Defaults to `"spawn"`: a Qt application is always multi-threaded and libraries
+    commonly used by Ewoks tasks (HDF5 in particular) are not fork-safe. Use
+    `mp_context=None` for the platform default instead, which is `"fork"` on Linux.
     """
 
     def __init__(self, *args, **kwargs):
@@ -83,6 +142,65 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             self.task_output_changed
         ]
         self.__post_task_exception: Optional[Exception] = None
+
+        self.__taskProgress = QProgress()
+        self.__taskProgress.sigProgressChanged.connect(self._onProgressChanged)
+
+        self.__executor = EwoksExecutor(
+            self._create_pool_executor(),
+            self._SUBMIT_POLICY,
+            mp_context=self._MP_CONTEXT,
+        )
+        self.__executor.submitted.connect(self.__on_submitted)
+        self.__executor.started.connect(self.__on_started)
+        self.__executor.succeeded.connect(self.__on_succeeded)
+        self.__executor.failed.connect(self.__on_failed)
+
+        self.__propagate_by_future: Dict[TaskFuture, bool] = {}
+        self.__propagate_next: bool = False
+
+        self.__last_output_variables: Optional[VariableContainer] = None
+        self.__last_task_succeeded: Optional[bool] = None
+        self.__last_task_done: Optional[bool] = None
+        self.__last_task_exception: Optional[Exception] = None
+
+        # Note: this might be removed in the future. Please avoid using it.
+        self.__current_task_future: Optional[TaskFuture] = None
+
+    @classmethod
+    def _create_pool_executor(cls) -> Optional[futures.Executor]:
+        """
+        Create the `concurrent.futures` executor that runs the Ewoks tasks.
+
+        Override to execute tasks in an executor that :class:`Concurrency` does
+        not cover.
+
+        :return: An executor or `None` to execute in the calling thread.
+        """
+        return create_pool_executor(cls._CONCURRENCY, cls._MAX_WORKERS, cls._MP_CONTEXT)
+
+    def onDeleteWidget(self):
+        """
+        Release the task executor and progress handling when the widget is removed.
+        """
+        self.__taskProgress.sigProgressChanged.disconnect(self._onProgressChanged)
+        self._cleanup_task_executor()
+        super().onDeleteWidget()
+
+    def _cleanup_task_executor(self) -> None:
+        """
+        Shut down the task executor without waiting for pending tasks.
+        """
+        self.__executor.shutdown(wait=False)
+        self.__executor = None
+
+    def _onProgressChanged(self, progress: int):
+        """
+        Forward Ewoks task progress to the Orange progress bar.
+
+        :param progress: Progress percentage.
+        """
+        self.progressBarSet(float(progress))
 
     # --- Control and Main area --------------------------------------------------------------
 
@@ -239,7 +357,7 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         return dict(
             filter(
                 lambda pair: not is_invalid_data(pair[1]),
-                _get_model_default_values(input_model).items(),
+                get_model_default_values(input_model).items(),
             )
         )
 
@@ -464,14 +582,21 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             names -= set(cls._ewoks_outputs_to_hide_from_orange)
         return names
 
-    def get_task_outputs(self, exclude_hidden: bool = False) -> dict:
+    def get_task_outputs(self, exclude_hidden: bool = False) -> Mapping[str, Variable]:
         """
         Return task output variables.
 
-        Subclasses must implement this to return a dict-like mapping of output name
-        to Variable.
+        :param exclude_hidden: Leave out the outputs hidden from Orange.
+        :return: The task's :class:`~ewokscore.variable.VariableContainer`, or a
+                 plain mapping when there are no outputs or when outputs were
+                 filtered out. The filtered result is deliberately not a
+                 `VariableContainer`: a new container would be a different
+                 hashable with its own `uhash`, while these are still the
+                 variables of the original one.
         """
         outputs = self._get_task_outputs()
+        if outputs is None:
+            return dict()
         if exclude_hidden:
             outputs = {
                 k: v
@@ -480,9 +605,16 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             }
         return outputs
 
-    @abstractmethod
-    def _get_task_outputs(self) -> dict:
-        raise NotImplementedError("Base class")
+    def _get_task_outputs(self) -> Optional[VariableContainer]:
+        """
+        Return the output variables produced by the last executed task.
+
+        :return: The task's :class:`~ewokscore.variable.VariableContainer`, or
+                 `None` when the last task failed or no task ran yet. An empty
+                 container cannot express that: it holds `MISSING_DATA` instead
+                 of a mapping, so `[]` and `in` raise `TypeError` on it.
+        """
+        return self.__last_output_variables
 
     def get_task_output_values(self, exclude_hidden: bool = False) -> dict:
         """
@@ -623,7 +755,10 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         Execute the Ewoks task and propagate downstream on completion.
 
         :param log_missing_inputs: Whether missing inputs should be logged.
-        :return: TaskFuture for async widgets, None for synchronous widgets.
+        :return: The future of the submitted task, whose result is the task's
+                 :class:`~ewokscore.variable.VariableContainer` of output
+                 variables. `None` when the submission was dropped by
+                 `SubmitPolicy.DROP_IF_BUSY`.
         """
         _logger.debug("%s: execute ewoks task (with propagation)", self)
         return self._execute_ewoks_task(
@@ -634,50 +769,76 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
         """
         Execute the Ewoks task without propagating outputs downstream.
 
-        :return: TaskFuture for async widgets, None for synchronous widgets.
+        :return: The future of the submitted task, or `None` when the submission
+                 was dropped by `SubmitPolicy.DROP_IF_BUSY`.
         """
         _logger.debug("%s: execute ewoks task (without propagation)", self)
         return self._execute_ewoks_task(propagate=False, log_missing_inputs=False)
 
     @property
-    @abstractmethod
+    def task_executor(self) -> EwoksExecutor:
+        """
+        The executor that runs the Ewoks tasks.
+
+        :return: The :class:`EwoksExecutor` instance.
+        """
+        return self.__executor
+
+    @property
     def task_succeeded(self) -> Optional[bool]:
         """
         Whether the most recent task execution succeeded.
 
         :return: True if succeeded, False if failed, or None if never run.
         """
-        raise NotImplementedError("Base class")
+        return self.__last_task_succeeded
 
     @property
-    @abstractmethod
     def task_done(self) -> Optional[bool]:
         """
         Whether the most recent task execution finished (success or failure).
 
         :return: True/False or None if never run.
         """
-        raise NotImplementedError("Base class")
+        return self.__last_task_done
 
     @property
-    @abstractmethod
     def task_exception(self) -> Optional[Exception]:
         """
         Exception raised during the most recent task execution, if any.
 
         :return: Exception instance or None.
         """
-        raise NotImplementedError("Base class")
+        exc = self.__last_task_exception
+        if exc is None:
+            return None
+        # task.execute() wraps run() exceptions as TaskExecutionError(...) from
+        # the original; follow __cause__ to surface the exception the task
+        # actually raised. Task construction failures (TaskInputError) have
+        # no __cause__ and are returned as-is.
+        return exc.__cause__ or exc
 
-    @abstractmethod
     def has_pending_task(self) -> bool:
         """
         Whether a task submission is outstanding, from submission until its
         completion callback (propagation + `progressBarFinished`) has run.
 
+        Always False when tasks execute synchronously (`concurrency="sync"`): the
+        completion callback has already run when the submission returns.
+
         :return: True while a submission is outstanding.
         """
-        raise NotImplementedError("Base class")
+        return bool(self.__propagate_by_future)
+
+    def cancel_running_task(self) -> None:
+        """Abort the currently running task."""
+        warnings.warn(
+            "'cancel_running_task' is deprecated since 6.0. Please cancel the task by calling the "
+            " `cancel` method of the future provided during task submission.",
+            DeprecationWarning,
+        )
+        if self.__current_task_future is not None:
+            self.__current_task_future.abort()
 
     @property
     def post_task_exception(self) -> Optional[Exception]:
@@ -706,11 +867,6 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             execinfo = scheme_ewoks_events(scheme, self._ewoks_execinfo)
 
         if self._ewoks_task_options:
-            print(
-                "self._ewoks_task_options = ",
-                self._ewoks_task_options,
-                type(self._ewoks_task_options),
-            )
             task_arguments = dict(self._ewoks_task_options)
         else:
             task_arguments = dict()
@@ -719,15 +875,13 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             varinfo=self._ewoks_varinfo,
             execinfo=execinfo,
             node_id=node_id,
+            progress=self.__taskProgress,
         )
         return task_arguments
 
     def _output_changed(self) -> None:
         """
         Called when the Ewoks task execution finishes and outputs changed.
-
-        This base class does not call it. It is up to the derived classes
-        that implement `_execute_ewoks_task` to call it.
 
         This invokes registered post-task callbacks.
         """
@@ -753,15 +907,86 @@ class OWEwoksBaseWidget(OWWidget, metaclass=OWEwoksWidgetMetaClass, **ow_build_o
             if ncallbacks > 1:
                 self.__post_task_execute(callbacks[1:])
 
-    @abstractmethod
     def _execute_ewoks_task(
         self, propagate: bool, log_missing_inputs: bool
     ) -> Optional[TaskFuture]:
         """
-        Subclasses must implement how the task is created and executed.
+        Submit the Ewoks task to the task executor.
 
         :param propagate: Whether to propagate outputs downstream after execution.
         :param log_missing_inputs: Whether to log missing input warnings.
         :return: TaskFuture or None when the execution request was rejected.
         """
-        raise NotImplementedError("Base class")
+        # Read back by `__on_submitted`. Submission always happens in the GUI
+        # thread so a single slot is enough.
+        self.__propagate_next = propagate
+        return self.__executor.submit_task(
+            self.ewokstaskclass, **self._get_task_arguments()
+        )
+
+    def __on_submitted(self, task_future: TaskFuture) -> None:
+        """
+        Remember whether the submitted task should propagate its outputs.
+
+        The `submitted` signal is emitted before the task can start, which is
+        why this cannot wait for `submit_task` to return: with synchronous
+        execution (`concurrency="sync"`) the task already completed by then.
+
+        :param task_future: The future of the submitted task.
+        """
+        self.__propagate_by_future[task_future] = self.__propagate_next
+
+    def __on_started(self, task_future: TaskFuture) -> None:
+        """
+        Start the Orange progress bar when the task starts executing.
+
+        :param task_future: The future of the started task.
+        """
+        self.__current_task_future = task_future
+        self.progressBarInit()
+
+    def __on_succeeded(self, task_future: TaskFuture) -> None:
+        """
+        Store the outputs of a successful task and propagate them downstream.
+
+        :param task_future: The future of the successful task.
+        """
+        propagate = self.__propagate_by_future.get(task_future, False)
+        self.__last_output_variables = task_future.result()
+        self.__last_task_succeeded = True
+        self.__last_task_done = True
+        self.__last_task_exception = None
+        # `propagate_downstream` must run before `progressBarFinished`: the
+        # latter flips `signal_manager.is_active(node)` to False, which is
+        # what `wait_widgets`-style polling relies on to know this widget is
+        # done. Clearing it first would let such polling observe "not
+        # active" before the outputs were actually sent downstream.
+        # `has_pending_task()` must stay True until both of those have run,
+        # for the same reason, so the future is only popped last.
+        try:
+            if propagate:
+                self.propagate_downstream(succeeded=True)
+        finally:
+            self.progressBarFinished()
+            self.__propagate_by_future.pop(task_future, None)
+            self._output_changed()
+
+    def __on_failed(self, task_future: TaskFuture) -> None:
+        """
+        Store the exception of a failed task and invalidate downstream nodes.
+
+        :param task_future: The future of the failed task.
+        """
+        propagate = self.__propagate_by_future.get(task_future, False)
+        self.__last_output_variables = None
+        self.__last_task_succeeded = False
+        self.__last_task_done = True
+        self.__last_task_exception = task_future.exception()
+        # See ordering note in `__on_succeeded`.
+        try:
+            if propagate:
+                self.propagate_downstream(succeeded=False)
+        finally:
+            self.progressBarFinished()
+            self.__propagate_by_future.pop(task_future, None)
+            self._output_changed()

--- a/src/ewoksorange/gui/owwidgets/meta.py
+++ b/src/ewoksorange/gui/owwidgets/meta.py
@@ -3,8 +3,12 @@ Metaclass and class preparation utilities for owwidgets package.
 """
 
 import inspect
+import multiprocessing
+import multiprocessing.context
 from abc import ABCMeta
 from typing import Any
+from typing import Optional
+from typing import Union
 
 from ...orange_version import ORANGE_VERSION
 
@@ -21,7 +25,11 @@ else:
 
         WidgetMetaClass = type(OWBaseWidget)
 
+from ..concurrency.executor import Concurrency
+from ..concurrency.executor import SubmitPolicy
 from ..orange_utils import _signals
+
+_NOT_PROVIDED = object()
 
 
 class OWEwoksWidgetMetaClass(ABCMeta, WidgetMetaClass):
@@ -29,19 +37,134 @@ class OWEwoksWidgetMetaClass(ABCMeta, WidgetMetaClass):
     Metaclass used to prepare widget classes with Ewoks bindings.
     """
 
-    def __new__(metacls, name, bases, attrs, ewokstaskclass=None, **kw):
+    def __new__(
+        metacls,
+        name,
+        bases,
+        attrs,
+        ewokstaskclass=None,
+        concurrency=_NOT_PROVIDED,
+        max_workers=_NOT_PROVIDED,
+        submit_policy=_NOT_PROVIDED,
+        mp_context=_NOT_PROVIDED,
+        **kw,
+    ):
         """
         Create a new widget class; if `ewokstaskclass` is provided prepare the class.
+
+        Execution arguments that are not provided are inherited from the base classes.
 
         :param name: New class name.
         :param bases: Base classes.
         :param attrs: Attribute dict for the class.
         :param ewokstaskclass: Optional Ewoks Task class to attach.
+        :param concurrency: Optional task execution backend (see
+                            :attr:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget._CONCURRENCY`).
+        :param max_workers: Optional maximum number of task workers (see
+                            :attr:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget._MAX_WORKERS`).
+        :param submit_policy: Optional task submission policy (see
+                              :attr:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget._SUBMIT_POLICY`).
+        :param mp_context: Optional multiprocessing context (see
+                           :attr:`~ewoksorange.gui.owwidgets.base.OWEwoksBaseWidget._MP_CONTEXT`).
         :return: Newly created class type.
         """
         if ewokstaskclass:
             _prepare_OWEwoksWidgetclass(attrs, ewokstaskclass)
+        if concurrency is not _NOT_PROVIDED:
+            attrs["_CONCURRENCY"] = _parse_concurrency(concurrency)
+        if max_workers is not _NOT_PROVIDED:
+            attrs["_MAX_WORKERS"] = _parse_max_workers(max_workers)
+        if submit_policy is not _NOT_PROVIDED:
+            attrs["_SUBMIT_POLICY"] = _parse_submit_policy(submit_policy)
+        if mp_context is not _NOT_PROVIDED:
+            attrs["_MP_CONTEXT"] = _parse_mp_context(mp_context)
         return super().__new__(metacls, name, bases, attrs, **kw)
+
+
+def _parse_concurrency(concurrency: Union[Concurrency, str]) -> Concurrency:
+    """
+    Validate the `concurrency` class argument.
+
+    :param concurrency: A :class:`Concurrency` or its (case-insensitive) name.
+    :raises ValueError: When the name is unknown.
+    :return: The corresponding :class:`Concurrency`.
+    """
+    if isinstance(concurrency, Concurrency):
+        return concurrency
+    if isinstance(concurrency, str):
+        try:
+            return Concurrency[concurrency.upper()]
+        except KeyError:
+            pass
+    names = ", ".join(repr(value.name.lower()) for value in Concurrency)
+    raise ValueError(
+        f"'concurrency' must be a Concurrency or one of {names}: {concurrency!r}"
+    )
+
+
+def _parse_max_workers(max_workers: Optional[int]) -> Optional[int]:
+    """
+    Validate the `max_workers` class argument.
+
+    :param max_workers: `None` or a positive integer.
+    :raises ValueError: When not a positive integer.
+    :return: The validated value.
+    """
+    if max_workers is None:
+        return None
+    if not isinstance(max_workers, int) or isinstance(max_workers, bool):
+        raise ValueError(f"'max_workers' must be None or an integer: {max_workers!r}")
+    if max_workers < 1:
+        raise ValueError(
+            f"'max_workers' must be None or a positive integer: {max_workers!r}"
+        )
+    return max_workers
+
+
+def _parse_submit_policy(submit_policy: Union[SubmitPolicy, str]) -> SubmitPolicy:
+    """
+    Validate the `submit_policy` class argument.
+
+    :param submit_policy: A :class:`SubmitPolicy` or its (case-insensitive) name.
+    :raises ValueError: When the name is unknown.
+    :return: The corresponding :class:`SubmitPolicy`.
+    """
+    if isinstance(submit_policy, SubmitPolicy):
+        return submit_policy
+    if isinstance(submit_policy, str):
+        try:
+            return SubmitPolicy[submit_policy.upper()]
+        except KeyError:
+            pass
+    names = ", ".join(repr(policy.name.lower()) for policy in SubmitPolicy)
+    raise ValueError(
+        f"'submit_policy' must be a SubmitPolicy or one of {names}: {submit_policy!r}"
+    )
+
+
+def _parse_mp_context(
+    mp_context: Union[None, str, multiprocessing.context.BaseContext],
+) -> Optional[multiprocessing.context.BaseContext]:
+    """
+    Validate the `mp_context` class argument.
+
+    :param mp_context: `None` for the platform default, a `multiprocessing`
+                       context or the name of a start method supported on this
+                       platform (for example `"spawn"`).
+    :raises ValueError: When the start method is not available.
+    :return: The corresponding `multiprocessing` context or `None`.
+    """
+    if mp_context is None or isinstance(
+        mp_context, multiprocessing.context.BaseContext
+    ):
+        return mp_context
+    available = multiprocessing.get_all_start_methods()
+    if not isinstance(mp_context, str) or mp_context not in available:
+        names = ", ".join(repr(name) for name in available)
+        raise ValueError(
+            f"'mp_context' must be None, a multiprocessing context or one of {names} on this platform: {mp_context!r}"
+        )
+    return multiprocessing.get_context(mp_context)
 
 
 # Ensure compatibility between old orange widget and new

--- a/src/ewoksorange/gui/owwidgets/nothread.py
+++ b/src/ewoksorange/gui/owwidgets/nothread.py
@@ -2,89 +2,16 @@
 Synchronous (no-thread) Ewoks widget implementation.
 """
 
-from typing import Optional
-
-from ..concurrency.executor import EwoksExecutor
-from ..concurrency.executor import SubmitPolicy
-from ..concurrency.executor import TaskFuture
+from ..concurrency.executor import Concurrency
 from .base import OWEwoksBaseWidget
 from .meta import ow_build_opts
 
 
-class OWEwoksWidgetNoThread(OWEwoksBaseWidget, **ow_build_opts):
+class OWEwoksWidgetNoThread(
+    OWEwoksBaseWidget, **ow_build_opts, concurrency=Concurrency.SYNC
+):
     """
     Widget that creates and executes an Ewoks Task synchronously on the main thread.
 
     Use this for lightweight tasks that won't block the UI.
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__executor = EwoksExecutor(None, SubmitPolicy.ALWAYS)
-
-        self.__last_output_variables: dict = {}
-        self.__last_task_succeeded: Optional[bool] = None
-        self.__last_task_done: Optional[bool] = None
-        self.__last_task_exception: Optional[Exception] = None
-
-    def _execute_ewoks_task(
-        self, propagate: bool, log_missing_inputs: bool
-    ) -> Optional[TaskFuture]:
-        """
-        Create and execute the Task synchronously.
-
-        :param propagate: Whether to propagate outputs after execution.
-        :param log_missing_inputs: Whether to log missing input warnings.
-        :return: TaskFuture, or None when the execution request was rejected.
-        """
-        task_future = self.__executor.submit_task(
-            self.ewokstaskclass, **self._get_task_arguments()
-        )
-        if task_future is None:
-            return None
-
-        # Submission runs (and completes) synchronously, so the result is
-        # already available here rather than through the executor's signals.
-        exception = task_future.exception()
-        self.__last_task_exception = exception
-        self.__last_task_succeeded = exception is None
-        self.__last_task_done = True
-        self.__last_output_variables = task_future.result() if exception is None else {}
-
-        try:
-            if propagate:
-                self.propagate_downstream(succeeded=exception is None)
-        finally:
-            self._output_changed()
-
-        return task_future
-
-    def has_pending_task(self) -> bool:
-        """Always False: submission runs synchronously to completion."""
-        return False
-
-    @property
-    def task_succeeded(self) -> Optional[bool]:
-        """Return True if last task succeeded, False if failed, None if never run."""
-        return self.__last_task_succeeded
-
-    @property
-    def task_done(self) -> Optional[bool]:
-        """Return True if last task finished (success/failure), None if never run."""
-        return self.__last_task_done
-
-    @property
-    def task_exception(self) -> Optional[Exception]:
-        """Return the exception raised during last task execution, if any."""
-        exc = self.__last_task_exception
-        if exc is None:
-            return None
-        # task.execute() wraps run() exceptions as TaskExecutionError(...) from
-        # the original; follow __cause__ to surface the exception the task
-        # actually raised. Task construction failures (TaskInputError) have
-        # no __cause__ and are returned as-is.
-        return exc.__cause__ or exc
-
-    def _get_task_outputs(self) -> dict:
-        """Return output variables produced by the last executed task."""
-        return self.__last_output_variables

--- a/src/ewoksorange/gui/owwidgets/threaded.py
+++ b/src/ewoksorange/gui/owwidgets/threaded.py
@@ -2,182 +2,43 @@
 Threaded Ewoks widget implementations.
 """
 
-from __future__ import annotations
-
 import warnings
-from concurrent.futures import ThreadPoolExecutor
-from typing import Dict
-from typing import Optional
 
+from ..concurrency.executor import Concurrency
 from ..concurrency.executor import EwoksExecutor
 from ..concurrency.executor import SubmitPolicy
-from ..concurrency.executor import TaskFuture
-from ..qt_utils.progress import QProgress
 from .base import OWEwoksBaseWidget
 from .meta import ow_build_opts
 
 
-class _OWEwoksThreadedBaseWidget(OWEwoksBaseWidget, **ow_build_opts):
-    """Common threaded behavior: progress handling and cleanup hooks."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__taskProgress = QProgress()
-        self.__taskProgress.sigProgressChanged.connect(self.__onProgressChanged)
-
-    def onDeleteWidget(self):
-        self.__taskProgress.sigProgressChanged.disconnect(self.__onProgressChanged)
-        self._cleanup_task_executor()
-        super().onDeleteWidget()
-
-    def _cleanup_task_executor(self):
-        raise NotImplementedError("Base class")
-
-    def _get_task_arguments(self):
-        adict = super()._get_task_arguments()
-        adict["progress"] = self.__taskProgress
-        return adict
-
-    def __onProgressChanged(self, progress: int):
-        self.progressBarSet(float(progress))
-
-
-class _OWEwoksExecutorWidget(_OWEwoksThreadedBaseWidget, **ow_build_opts):
-    """Base for all EwoksExecutor-backed widgets."""
-
-    _MAX_WORKERS: Optional[int] = None
-    _SUBMIT_POLICY: SubmitPolicy = SubmitPolicy.ALWAYS
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__executor = EwoksExecutor(
-            ThreadPoolExecutor(max_workers=self._MAX_WORKERS),
-            self._SUBMIT_POLICY,
-        )
-        self.__executor.started.connect(self.__on_started)
-        self.__executor.succeeded.connect(self.__on_succeeded)
-        self.__executor.failed.connect(self.__on_failed)
-        self.__propagate_by_future: Dict[TaskFuture, bool] = {}
-
-        # Note: all the following variables might be removed in the future. Please avoid using them.
-        self.__current_task_future: Optional[TaskFuture] = None
-        self.__last_output_variables: dict = {}
-        self.__last_task_succeeded: Optional[bool] = None
-        self.__last_task_done: Optional[bool] = None
-        self.__last_task_exception: Optional[Exception] = None
-
-    def _execute_ewoks_task(
-        self, propagate: bool, log_missing_inputs: bool
-    ) -> Optional[TaskFuture]:
-        """
-        :param propagate: Whether to propagate outputs downstream after execution.
-        :param log_missing_inputs: Whether to log missing input warnings.
-        :return: TaskFuture or None when the execution request was rejected.
-        """
-        task_future = self.__executor.submit_task(
-            self.ewokstaskclass, **self._get_task_arguments()
-        )
-        if task_future is not None:
-            self.__propagate_by_future[task_future] = propagate
-        return task_future
-
-    def __on_started(self, task_future: TaskFuture) -> None:
-        self.__current_task_future = task_future
-        self.progressBarInit()
-
-    def __on_succeeded(self, task_future: TaskFuture) -> None:
-        propagate = self.__propagate_by_future.get(task_future, False)
-        self.__last_output_variables = task_future.result()
-        self.__last_task_succeeded = True
-        self.__last_task_done = True
-        self.__last_task_exception = None
-        # `propagate_downstream` must run before `progressBarFinished`: the
-        # latter flips `signal_manager.is_active(node)` to False, which is
-        # what `wait_widgets`-style polling relies on to know this widget is
-        # done. Clearing it first would let such polling observe "not
-        # active" before the outputs were actually sent downstream.
-        # `has_pending_task()` must stay True until both of those have run,
-        # for the same reason, so the future is only popped last.
-        try:
-            if propagate:
-                self.propagate_downstream(succeeded=True)
-        finally:
-            self.progressBarFinished()
-            self.__propagate_by_future.pop(task_future, None)
-            self._output_changed()
-
-    def __on_failed(self, task_future: TaskFuture) -> None:
-        propagate = self.__propagate_by_future.get(task_future, False)
-        self.__last_output_variables = {}
-        self.__last_task_succeeded = False
-        self.__last_task_done = True
-        self.__last_task_exception = task_future.exception()
-        # See ordering note in `__on_succeeded`.
-        try:
-            if propagate:
-                self.propagate_downstream(succeeded=False)
-        finally:
-            self.progressBarFinished()
-            self.__propagate_by_future.pop(task_future, None)
-            self._output_changed()
-
-    @property
-    def task_executor(self) -> EwoksExecutor:
-        """The underlying :class:`EwoksExecutor`."""
-        return self.__executor
-
-    def has_pending_task(self) -> bool:
-        return bool(self.__propagate_by_future)
-
-    @property
-    def task_succeeded(self) -> Optional[bool]:
-        return self.__last_task_succeeded
-
-    @property
-    def task_done(self) -> Optional[bool]:
-        return self.__last_task_done
-
-    @property
-    def task_exception(self) -> Optional[Exception]:
-        exc = self.__last_task_exception
-        # task.execute() wraps run() exceptions as RuntimeError(...) from original;
-        # follow __cause__ to surface the exception the task actually raised.
-        return exc.__cause__ or exc if exc is not None else None
-
-    def _get_task_outputs(self) -> dict:
-        return self.__last_output_variables
-
-    def _cleanup_task_executor(self) -> None:
-        self.__executor.shutdown(wait=False)
-        self.__executor = None
-
-    def cancel_running_task(self) -> None:
-        """Abort the currently running task."""
-        warnings.warn(
-            "'cancel_running_task' is deprecated since 6.0. Please cancel the task by calling the  `cancel` method of the future provided during task submission.",
-            DeprecationWarning,
-        )
-        if self.__current_task_future is not None:
-            self.__current_task_future.abort()
-
-
-class OWEwoksWidgetOneThread(_OWEwoksExecutorWidget, **ow_build_opts):
+class OWEwoksWidgetOneThread(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    concurrency=Concurrency.THREAD,
+    max_workers=1,
+    submit_policy=SubmitPolicy.DROP_IF_BUSY,
+):
     """Single background thread; submissions while busy are dropped."""
 
-    _MAX_WORKERS: Optional[int] = 1
-    _SUBMIT_POLICY = SubmitPolicy.DROP_IF_BUSY
 
-
-class OWEwoksWidgetOneThreadPerRun(_OWEwoksExecutorWidget, **ow_build_opts):
+class OWEwoksWidgetOneThreadPerRun(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    concurrency=Concurrency.THREAD,
+    max_workers=None,
+    submit_policy=SubmitPolicy.ALWAYS,
+):
     """Submits each task to a shared thread pool; multiple runs may overlap."""
 
-    _MAX_WORKERS = None
 
-
-class OWEwoksWidgetWithTaskStack(_OWEwoksExecutorWidget, **ow_build_opts):
+class OWEwoksWidgetWithTaskStack(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    concurrency=Concurrency.THREAD,
+    max_workers=1,
+    submit_policy=SubmitPolicy.ALWAYS,
+):
     """FIFO queue: tasks are queued and run sequentially in a single thread."""
-
-    _MAX_WORKERS: Optional[int] = 1
 
     @property
     def task_executor_queue(self) -> EwoksExecutor:

--- a/src/ewoksorange/gui/qt_utils/progress.py
+++ b/src/ewoksorange/gui/qt_utils/progress.py
@@ -4,12 +4,8 @@ from ewokscore.progress import BasePercentageProgress
 
 
 class QProgress(QObject, BasePercentageProgress):
-    """
-    Progress associated to a QObject.
-    This is connected to the Orange :class:'ProgressBar' from classes:
-    * :class:`OWEwoksWidgetOneThread`
-    * :class:`OWEwoksWidgetWithTaskStack`
-    """
+    """Progress associated to a QObject used as an Ewoks task argument
+    to report task execution progress."""
 
     sigProgressChanged = Signal(int)
 

--- a/src/ewoksorange/gui/utils/model.py
+++ b/src/ewoksorange/gui/utils/model.py
@@ -1,15 +1,15 @@
-from __future__ import annotations
-
 from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import Tuple
+from typing import Type
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
 
-def _get_model_default_values(model: type[BaseModel]) -> dict[str, Any]:
+def get_model_default_values(model: Type[BaseModel]) -> Dict[str, Any]:
     """
-    Docstring for _get_model_default_values
-
     :return: Dict of input name -> value or missing marker.
     """
     field_with_values = filter(
@@ -19,6 +19,6 @@ def _get_model_default_values(model: type[BaseModel]) -> dict[str, Any]:
     return dict(field_with_values)
 
 
-def _get_default_field_factory(model):
+def _get_default_field_factory(model) -> Iterator[Tuple[str, Any]]:
     for field_name, field in model.model_fields.items():
         yield field_name, field.default

--- a/src/ewoksorange/tests/executor/conftest.py
+++ b/src/ewoksorange/tests/executor/conftest.py
@@ -1,32 +1,29 @@
-from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Generator
 from typing import Tuple
 
 import pytest
 
+from ...gui.concurrency.executor import Concurrency
 from ...gui.concurrency.executor import EwoksExecutor
 from ...gui.concurrency.executor import SubmitPolicy
+from ...gui.concurrency.executor import create_pool_executor
 from .signals import SignalRecorder
 
 
-@pytest.fixture(params=["sync", "thread", "process"])
+@pytest.fixture(params=list(Concurrency), ids=lambda c: c.name.lower())
 def executor_context_factory(request):
 
-    kind = request.param
+    concurrency = request.param
+    kind = concurrency.name.lower()
 
     @contextmanager
     def executor_context(
         policy=SubmitPolicy.ALWAYS, workers=2
     ) -> Generator[Tuple[str, EwoksExecutor, SignalRecorder], None, None]:
 
-        if kind == "sync":
-            executor = EwoksExecutor(None, policy)
-        elif kind == "thread":
-            executor = EwoksExecutor(ThreadPoolExecutor(max_workers=workers), policy)
-        else:
-            executor = EwoksExecutor(ProcessPoolExecutor(max_workers=workers), policy)
+        pool = create_pool_executor(concurrency, max_workers=workers)
+        executor = EwoksExecutor(pool, policy)
 
         recorder = SignalRecorder()
         recorder.connect(executor)

--- a/src/ewoksorange/tests/executor/tasks.py
+++ b/src/ewoksorange/tests/executor/tasks.py
@@ -1,5 +1,7 @@
+import os
 import time
 
+from ewokscore import TaskWithProgress
 from ewokscore.task import Task
 
 
@@ -148,3 +150,28 @@ class TimedTask(
         self.outputs.start = start
         self.outputs.end = time.monotonic()
         self.outputs.value = self.inputs.value
+
+
+class ProgressTask(
+    TaskWithProgress,
+    input_names=["percentages"],
+    output_names=["pid"],
+):
+    """Reports each of `percentages` as task progress.
+
+    Also outputs the pid it ran in, so tests can tell the execution backends
+    apart.
+    """
+
+    def run(self) -> None:
+        for percentage in self.inputs.percentages:
+            self.progress = percentage
+        self.outputs.pid = os.getpid()
+
+
+class PidTask(Task, input_names=["value"], output_names=["value", "pid"]):
+    """Outputs the pid it ran in. Not a `TaskWithProgress`."""
+
+    def run(self) -> None:
+        self.outputs.value = self.inputs.value
+        self.outputs.pid = os.getpid()

--- a/src/ewoksorange/tests/executor/test_executor_progress.py
+++ b/src/ewoksorange/tests/executor/test_executor_progress.py
@@ -1,0 +1,67 @@
+"""Ewoks task progress reaches the caller for every execution backend."""
+
+import os
+from typing import List
+
+from ...gui.qt_utils.progress import QProgress
+from .tasks import PidTask
+from .tasks import ProgressTask
+
+
+def test_progress(qtapp, executor_context_factory):
+    """The caller's progress object receives every value the task reports.
+
+    `QProgress` is a `QObject` and therefore not picklable, which the process
+    backend has to work around without the caller noticing.
+    """
+    percentages = [10, 40, 100]
+
+    with executor_context_factory() as (kind, executor, recorder):
+        progress = QProgress()
+        received: List[int] = []
+        progress.sigProgressChanged.connect(received.append)
+
+        future = executor.submit_task(
+            ProgressTask, inputs={"percentages": percentages}, progress=progress
+        )
+
+        result = future.result(timeout=30)
+
+        # `finished` is only emitted once all progress values were relayed, so
+        # no polling on `received` is needed here.
+        recorder.wait_for("finished", 1)
+
+        assert received == percentages
+        assert progress.progress == 100
+
+        if kind == "process":
+            assert result["pid"].value != os.getpid()
+        else:
+            assert result["pid"].value == os.getpid()
+
+
+def test_progress_for_task_without_progress_support(qtapp, executor_context_factory):
+    """A `progress` argument for a plain `Task` is dropped, not forwarded.
+
+    For the process backend it must be dropped before pickling, otherwise
+    submitting any `Task` with a Qt bound progress object fails.
+    """
+    with executor_context_factory() as (kind, executor, recorder):
+        progress = QProgress()
+        received: List[int] = []
+        progress.sigProgressChanged.connect(received.append)
+
+        future = executor.submit_task(PidTask, inputs={"value": 3}, progress=progress)
+
+        result = future.result(timeout=30)
+
+        recorder.wait_for("finished", 1)
+        recorder.assert_counts(submitted=1, started=1, succeeded=1, finished=1)
+
+        assert result["value"].value == 3
+        assert received == []
+
+        if kind == "process":
+            assert result["pid"].value != os.getpid()
+        else:
+            assert result["pid"].value == os.getpid()

--- a/src/ewoksorange/tests/owwidget/test_owwidget_config.py
+++ b/src/ewoksorange/tests/owwidget/test_owwidget_config.py
@@ -244,7 +244,9 @@ def test_configure_process_progress(qtapp):
     widget = OWProcessProgress()
     received: List[int] = []
     # The public Orange method the widget's progress handler calls.
-    widget.progressBarSet = received.append
+    # `progressBarInit()` passes a second `processEvents` argument on some
+    # Orange forks (e.g. oasys), so accept and ignore extra arguments.
+    widget.progressBarSet = lambda value, *args, **kwargs: received.append(value)
     try:
         widget.set_dynamic_input("percentages", percentages)
 

--- a/src/ewoksorange/tests/owwidget/test_owwidget_config.py
+++ b/src/ewoksorange/tests/owwidget/test_owwidget_config.py
@@ -1,0 +1,344 @@
+"""Configure task execution directly on `OWEwoksBaseWidget`."""
+
+import multiprocessing
+import os
+import threading
+import time
+from typing import List
+
+import numpy
+import pytest
+from ewokscore.task import Task
+
+from ...gui.concurrency.executor import Concurrency
+from ...gui.concurrency.executor import SubmitPolicy
+from ...gui.owwidgets.base import OWEwoksBaseWidget
+from ...gui.owwidgets.meta import ow_build_opts
+from ...gui.owwidgets.nothread import OWEwoksWidgetNoThread
+from ...gui.owwidgets.threaded import OWEwoksWidgetOneThread
+from ...gui.owwidgets.threaded import OWEwoksWidgetOneThreadPerRun
+from ...gui.owwidgets.threaded import OWEwoksWidgetWithTaskStack
+from ...gui.qt_utils.app import wait_until
+
+# The process backend pickles the task class by reference, so the child process
+# imports its module. These are Qt-free, unlike this test module.
+from ..executor.tasks import PidTask
+from ..executor.tasks import ProgressTask
+
+
+class Sequential(
+    Task, input_names=["value", "sleep"], output_names=["value", "time", "thread_id"]
+):
+    def run(self):
+        time.sleep(self.inputs.sleep)
+        self.outputs.time = time.perf_counter()
+        self.outputs.value = self.inputs.value
+        self.outputs.thread_id = threading.get_ident()
+
+
+class Blocking(Task, input_names=["release"], output_names=["value"]):
+    def run(self):
+        assert self.inputs.release.wait(timeout=10)
+        self.outputs.value = 1
+
+
+class OWDefault(OWEwoksBaseWidget, **ow_build_opts, ewokstaskclass=Sequential):
+    name = "test_OW_default"
+
+
+class OWSync(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    ewokstaskclass=Sequential,
+    concurrency=Concurrency.SYNC,
+):
+    name = "test_OW_sync"
+
+
+class OWPool(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    ewokstaskclass=Sequential,
+    concurrency="thread",
+    max_workers=4,
+):
+    name = "test_OW_pool"
+
+
+class OWDropIfBusy(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    ewokstaskclass=Blocking,
+    max_workers=1,
+    submit_policy="drop_if_busy",
+):
+    name = "test_OW_drop"
+
+
+class OWProcess(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    ewokstaskclass=PidTask,
+    concurrency="process",
+    max_workers=1,
+):
+    name = "test_OW_process"
+
+
+class OWProcessProgress(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    ewokstaskclass=ProgressTask,
+    concurrency=Concurrency.PROCESS,
+    max_workers=1,
+):
+    name = "test_OW_process_progress"
+
+
+class OWProcessPlatformContext(
+    OWEwoksBaseWidget,
+    **ow_build_opts,
+    ewokstaskclass=PidTask,
+    concurrency="process",
+    max_workers=1,
+    mp_context=None,
+):
+    name = "test_OW_process_platform_context"
+
+
+def test_default_configuration():
+    """Without class arguments: one task at a time in a single worker thread."""
+    assert OWDefault._CONCURRENCY is Concurrency.THREAD
+    assert OWDefault._MAX_WORKERS == 1
+    assert OWDefault._SUBMIT_POLICY is SubmitPolicy.ALWAYS
+    assert OWDefault._MP_CONTEXT.get_start_method() == "spawn"
+
+
+@pytest.mark.parametrize(
+    "widget_class,concurrency,max_workers,submit_policy",
+    [
+        (OWEwoksWidgetNoThread, Concurrency.SYNC, 1, SubmitPolicy.ALWAYS),
+        (OWEwoksWidgetOneThread, Concurrency.THREAD, 1, SubmitPolicy.DROP_IF_BUSY),
+        (OWEwoksWidgetOneThreadPerRun, Concurrency.THREAD, None, SubmitPolicy.ALWAYS),
+        (OWEwoksWidgetWithTaskStack, Concurrency.THREAD, 1, SubmitPolicy.ALWAYS),
+    ],
+)
+def test_legacy_classes_are_configurations(
+    widget_class, concurrency, max_workers, submit_policy
+):
+    """The pre-existing classes only differ from the base class by configuration."""
+    assert widget_class.__bases__ == (OWEwoksBaseWidget,)
+    assert widget_class._CONCURRENCY is concurrency
+    assert widget_class._MAX_WORKERS == max_workers
+    assert widget_class._SUBMIT_POLICY is submit_policy
+
+
+def test_configure_sync(qtapp):
+    """`concurrency="sync"` executes in the calling thread."""
+    widget = OWSync()
+    try:
+        widget.set_dynamic_input("value", 1)
+        widget.set_dynamic_input("sleep", 0)
+
+        future = widget.execute_ewoks_task()
+
+        # Everything already happened when the submission returns.
+        assert future.done()
+        assert not widget.has_pending_task()
+        assert widget.task_succeeded
+        assert widget.get_task_output_values()["value"] == 1
+        assert widget.get_task_output_values()["thread_id"] == threading.get_ident()
+    finally:
+        widget.onDeleteWidget()
+
+
+def test_configure_pool(qtapp):
+    """`max_workers>1` executes tasks concurrently in background threads."""
+    widget = OWPool()
+    try:
+        sleep_seconds = 0.5
+        futures = []
+        for value in range(4):
+            widget.set_dynamic_input("value", value)
+            widget.set_dynamic_input("sleep", sleep_seconds)
+            futures.append(widget.execute_ewoks_task())
+
+        times = []
+        for future in futures:
+            outputs = future.result(timeout=10)
+            times.append(outputs["time"].value)
+            assert outputs["thread_id"].value != threading.get_ident()
+
+        assert (numpy.diff(sorted(times)) < 0.5 * sleep_seconds).all(), (
+            "not executed in parallel"
+        )
+    finally:
+        widget.onDeleteWidget()
+
+
+def test_configure_drop_if_busy(qtapp):
+    """`submit_policy="drop_if_busy"` refuses submissions while a task runs."""
+    widget = OWDropIfBusy()
+    release = threading.Event()
+    try:
+        widget.set_dynamic_input("release", release)
+
+        first = widget.execute_ewoks_task()
+        assert first is not None
+
+        assert widget.execute_ewoks_task() is None
+        assert widget.execute_ewoks_task_without_propagation() is None
+
+        release.set()
+        assert first.result(timeout=10)["value"].value == 1
+    finally:
+        release.set()
+        widget.onDeleteWidget()
+
+
+def test_configure_mp_context():
+    """`mp_context` accepts a `multiprocessing` context, a start method name or
+    `None` for the platform default."""
+    assert OWProcess._MP_CONTEXT.get_start_method() == "spawn"
+    assert OWProcessPlatformContext._MP_CONTEXT is None
+
+    # "spawn" is the only start method available on all platforms.
+    context = multiprocessing.get_context("spawn")
+
+    class OWContext(
+        OWEwoksBaseWidget,
+        **ow_build_opts,
+        ewokstaskclass=PidTask,
+        concurrency="process",
+        mp_context=context,
+    ):
+        name = "test_OW_mp_context"
+
+    assert OWContext._MP_CONTEXT is context
+
+
+@pytest.mark.parametrize("widget_class", [OWProcess, OWProcessPlatformContext])
+def test_configure_process(qtapp, widget_class):
+    """`concurrency="process"` executes in another process."""
+    widget = widget_class()
+    try:
+        widget.set_dynamic_input("value", 3)
+
+        widget.execute_ewoks_task()
+
+        assert wait_until(lambda: not widget.has_pending_task(), timeout=120)
+        assert widget.task_exception is None
+        assert widget.task_succeeded
+
+        outputs = widget.get_task_output_values()
+        assert outputs["value"] == 3
+        assert outputs["pid"] != os.getpid()
+    finally:
+        widget.onDeleteWidget()
+
+
+def test_configure_process_progress(qtapp):
+    """Task progress is relayed from the worker process to the progress bar."""
+    percentages = [10, 40, 100]
+
+    widget = OWProcessProgress()
+    received: List[int] = []
+    # The public Orange method the widget's progress handler calls.
+    widget.progressBarSet = received.append
+    try:
+        widget.set_dynamic_input("percentages", percentages)
+
+        widget.execute_ewoks_task()
+
+        assert wait_until(lambda: not widget.has_pending_task(), timeout=120)
+        assert widget.task_exception is None
+
+        assert widget.get_task_output_values()["pid"] != os.getpid()
+        # `progressBarInit` reports 0 before the task starts.
+        assert received == [0] + percentages
+    finally:
+        widget.onDeleteWidget()
+
+
+def test_configure_propagation(qtapp):
+    """Propagation is per submission, also when executing synchronously."""
+    propagated = []
+
+    class OWPropagate(
+        OWEwoksBaseWidget,
+        **ow_build_opts,
+        ewokstaskclass=Sequential,
+        concurrency="sync",
+    ):
+        name = "test_OW_propagate"
+
+        def trigger_downstream(self):
+            propagated.append("trigger_downstream")
+
+        def clear_downstream(self):
+            propagated.append("clear_downstream")
+
+    widget = OWPropagate()
+    try:
+        widget.set_dynamic_input("value", 1)
+        widget.set_dynamic_input("sleep", 0)
+
+        widget.execute_ewoks_task_without_propagation()
+        assert propagated == []
+
+        widget.execute_ewoks_task()
+        assert propagated == ["trigger_downstream"]
+    finally:
+        widget.onDeleteWidget()
+
+
+@pytest.mark.parametrize("concurrency", ["threads", "", 1, None])
+def test_invalid_concurrency(concurrency):
+    with pytest.raises(ValueError, match="concurrency"):
+
+        class OWInvalid(
+            OWEwoksBaseWidget,
+            **ow_build_opts,
+            ewokstaskclass=Sequential,
+            concurrency=concurrency,
+        ):
+            name = "test_OW_invalid"
+
+
+@pytest.mark.parametrize("max_workers", [0, -1, 1.5, "1", True])
+def test_invalid_max_workers(max_workers):
+    with pytest.raises(ValueError, match="max_workers"):
+
+        class OWInvalid(
+            OWEwoksBaseWidget,
+            **ow_build_opts,
+            ewokstaskclass=Sequential,
+            max_workers=max_workers,
+        ):
+            name = "test_OW_invalid"
+
+
+@pytest.mark.parametrize("submit_policy", ["never", 1, None])
+def test_invalid_submit_policy(submit_policy):
+    with pytest.raises(ValueError, match="submit_policy"):
+
+        class OWInvalid(
+            OWEwoksBaseWidget,
+            **ow_build_opts,
+            ewokstaskclass=Sequential,
+            submit_policy=submit_policy,
+        ):
+            name = "test_OW_invalid"
+
+
+@pytest.mark.parametrize("mp_context", ["threads", "", 1])
+def test_invalid_mp_context(mp_context):
+    with pytest.raises(ValueError, match="mp_context"):
+
+        class OWInvalid(
+            OWEwoksBaseWidget,
+            **ow_build_opts,
+            ewokstaskclass=Sequential,
+            mp_context=mp_context,
+        ):
+            name = "test_OW_invalid"


### PR DESCRIPTION
`OWEwoksBaseWidget` now has everything: task executor and progress handling.

_Task progress_ handling for sub-processes needed another queue `progress_queue` similar to `started_queue`.

FYI _abort_ is not changed in this PR.